### PR TITLE
[Bugfix] Resend Verification Email Link

### DIFF
--- a/resources/views/auth/verify.blade.php
+++ b/resources/views/auth/verify.blade.php
@@ -19,7 +19,13 @@
                     @endif
 
                     {{ __('Before proceeding, please check your email for a verification link.') }}
-                    {{ __('If you did not receive the email') }}, <a href="{{ route('verification.resend') }}">{{ __('click here to request another') }}</a>.
+                    {{ __('If you did not receive the email') }},
+                        <a href="{{ route('verification.resend') }}"
+                           onclick="event.preventDefault(); document.getElementById('verification-resend-form').submit();"
+                        >{{ __('click here to request another') }}</a>.
+                    <form id="verification-resend-form" action="{{ route('verification.resend') }}" method="POST" style="display: none;">
+                        {{ csrf_field() }}
+                    </form>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Description
Fix the link for resending a verification email, as it was previously a bare link but should have been a form to POST to the endpoint.