### PR TITLE
Bugfix - Message URL Click Count

### DIFF
--- a/src/Models/MessageUrl.php
+++ b/src/Models/MessageUrl.php
@@ -4,5 +4,6 @@ namespace Sendportal\Base\Models;
 
 class MessageUrl extends BaseModel
 {
+    /** @var array */
     protected $guarded = [];
 }

--- a/src/Models/MessageUrl.php
+++ b/src/Models/MessageUrl.php
@@ -2,8 +2,6 @@
 
 namespace Sendportal\Base\Models;
 
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-
 class MessageUrl extends BaseModel
 {
     protected $guarded = [];

--- a/src/Services/Webhooks/EmailWebhookService.php
+++ b/src/Services/Webhooks/EmailWebhookService.php
@@ -89,17 +89,20 @@ class EmailWebhookService
             DB::table('automation_steps')->where('id', $automationStep->id)->increment('click_count');
         }
 
-        /** @var MessageUrl $messageUrl */
-        $messageUrl = MessageUrl::updateOrCreate([
-            'hash' => md5($message->source_type . '_' . $message->source_id . '_' . $url),
-        ], [
-            'source_type' => $message->source_type,
-            'source_id' => $message->source_id,
-            'url' => $url
-        ]);
-
-        if (!$messageUrl->wasRecentlyCreated) {
-            DB::table('message_urls')->where('id', $messageUrl->id)->increment('click_count');
+        $messageUrlHash = $this->generateMessageUrlHash($message, $url);
+        
+        if($messageUrl = MessageUrl::where('hash', $messageUrlHash)->first()) {
+            $messageUrl->update([
+                'click_count' => $messageUrl->click_count + 1,
+            ]);
+        } else {
+            MessageUrl::create([
+                'hash' => $messageUrlHash,
+                'source_type' => $message->source_type,
+                'source_id' => $message->source_id,
+                'url' => $url,
+                'click_count' => 1,
+            ]);
         }
     }
 
@@ -192,5 +195,10 @@ class EmailWebhookService
         }
 
         return DB::table('automation_steps')->where('id', $automationSchedule->automation_step_id)->first();
+    }
+
+    protected function generateMessageUrlHash(Message $message, string $url): string
+    {
+        return md5($message->source_type . '_' . $message->source_id . '_' . $url);
     }
 }

--- a/src/Services/Webhooks/EmailWebhookService.php
+++ b/src/Services/Webhooks/EmailWebhookService.php
@@ -90,8 +90,8 @@ class EmailWebhookService
         }
 
         $messageUrlHash = $this->generateMessageUrlHash($message, $url);
-        
-        if($messageUrl = MessageUrl::where('hash', $messageUrlHash)->first()) {
+
+        if ($messageUrl = MessageUrl::where('hash', $messageUrlHash)->first()) {
             $messageUrl->update([
                 'click_count' => $messageUrl->click_count + 1,
             ]);


### PR DESCRIPTION
## Description
This PR addresses a bug which would result in a Message URL's click count falling out of sync. Previously, when creating a Message URL in response to a first-time click - we'd persist it with a `click_count` of 0 and fail to increment said value. Now, newly created Messages URLs are stored with a `click_count` of 1.