### PR TITLE
Check database driver before using date_format function (PostgreSQL fix)

### DIFF
--- a/src/Repositories/SubscriberTenantRepository.php
+++ b/src/Repositories/SubscriberTenantRepository.php
@@ -140,6 +140,10 @@ class SubscriberTenantRepository extends BaseTenantRepository
 
     public function getGrowthChartData(CarbonPeriod $period, int $workspaceId): array
     {
+        $rawQuery = config('database.default') === 'pgsql'
+            ? "to_char(created_at, 'dd-mm-YYYY') AS date, count(*) as total"
+            : "date_format(created_at, '%d-%m-%Y') AS date, count(*) as total";
+
         $startingValue = DB::table('subscribers')
             ->where('workspace_id', $workspaceId)
             ->where(function ($q) use ($period) {
@@ -150,7 +154,7 @@ class SubscriberTenantRepository extends BaseTenantRepository
             ->count();
 
         $runningTotal = DB::table('subscribers')
-            ->selectRaw("date_format(created_at, '%d-%m-%Y') AS date, count(*) as total")
+            ->selectRaw($rawQuery)
             ->where('workspace_id', $workspaceId)
             ->where('created_at', '>=', $period->getStartDate())
             ->where('created_at', '<=', $period->getEndDate())
@@ -158,7 +162,7 @@ class SubscriberTenantRepository extends BaseTenantRepository
             ->get();
 
         $unsubscribers = DB::table('subscribers')
-            ->selectRaw("date_format(unsubscribed_at, '%d-%m-%Y') AS date, count(*) as total")
+            ->selectRaw($rawQuery)
             ->where('workspace_id', $workspaceId)
             ->where('unsubscribed_at', '>=', $period->getStartDate())
             ->where('unsubscribed_at', '<=', $period->getEndDate())


### PR DESCRIPTION
After installing using postgresql database, an error showed up informing that "date_format function doesn't exist".
The problem is in this file:
vendor/mettle/sendportal-core/src/Repositories/SubscriberTenantRepository.php

From line 152 to 166:
` $runningTotal = DB::table('subscribers')
->selectRaw("date_format(created_at, '%d-%m-%Y') AS date, count(*) as total")
->where('workspace_id', $workspaceId)
->where('created_at', '>=', $period->getStartDate())
->where('created_at', '<=', $period->getEndDate())
->groupBy('date')
->get();

    $unsubscribers = DB::table('subscribers')
        ->selectRaw("date_format(unsubscribed_at, '%d-%m-%Y') AS date, count(*) as total")
        ->where('workspace_id', $workspaceId)
        ->where('unsubscribed_at', '>=', $period->getStartDate())
        ->where('unsubscribed_at', '<=', $period->getEndDate())
        ->groupBy('date')
        ->get();`
On postgresql you can use the function "to_char" instead of "date_format" since it doesn't exist:
`->selectRaw("to_char(created_at, 'dd-mm-yyyy') AS date`

[Issue referenced here](https://github.com/mettle/sendportal/issues/14)