### PR TITLE
[BUGFIX] Only fetch campaigns with `scheduled_at` in the past

### DIFF
--- a/src/Console/Commands/CampaignDispatchCommand.php
+++ b/src/Console/Commands/CampaignDispatchCommand.php
@@ -62,6 +62,8 @@ class CampaignDispatchCommand extends Command
      */
     protected function getQueuedCampaigns(): EloquentCollection
     {
-        return Campaign::where('status_id', CampaignStatus::STATUS_QUEUED)->get();
+        return Campaign::where('status_id', CampaignStatus::STATUS_QUEUED)
+            ->where('scheduled_at', '<=', now())
+            ->get();
     }
 }


### PR DESCRIPTION
We aren't checking for `scheduled_at` when dispatching campaigns, so a scheduled campaign will be dispatched immediately.