### PR TITLE
Add Campaign Endpoints to API

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -267,5 +267,6 @@
     "id": "id",
     "last_name": "last_name",
     "subscribers": "subscribers",
-    "The campaign must have a status of draft to be dispatched": "The campaign must have a status of draft to be dispatched"
+    "The campaign must have a status of draft to be dispatched": "The campaign must have a status of draft to be dispatched",
+    "A campaign cannot be updated if its status is not draft": "A campaign cannot be updated if its status is not draft"
 }

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -266,5 +266,6 @@
     "first_name": "first_name",
     "id": "id",
     "last_name": "last_name",
-    "subscribers": "subscribers"
+    "subscribers": "subscribers",
+    "The campaign must have a status of draft to be dispatched": "The campaign must have a status of draft to be dispatched"
 }

--- a/resources/views/campaigns/preview.blade.php
+++ b/resources/views/campaigns/preview.blade.php
@@ -82,13 +82,17 @@
                 <div class="form-group row form-group-recipients">
                     <div class="col-sm-12">
                         <select id="id-field-recipients" class="form-control" name="recipients">
-                            <option value="send_to_all" {{ old('recipients') == 'send_to_all' ? 'selected' : '' }}>{{ __('All subscribers') }} ({{ $subscriberCount }})</option>
-                            <option value="send_to_segments" {{ old('recipients') == 'send_to_segments' ? 'selected' : '' }}>{{ __('Select Segments') }}</option>
+                            <option value="send_to_all" {{ (old('recipients') == 'send_to_all' || $campaign->send_to_all) ? 'selected' : '' }}>
+                                {{ __('All subscribers') }} ({{ $subscriberCount }})
+                            </option>
+                            <option value="send_to_segments" {{ (old('recipients') == 'send_to_segments' || ! $campaign->send_to_all) ? 'selected' : '' }}>
+                                {{ __('Select Segments') }}
+                            </option>
                         </select>
                     </div>
                 </div>
 
-                <div class="segments-container {{ old('recipients') == 'send_to_segments' ? '' : 'hide' }}">
+                <div class="segments-container {{ (old('recipients') == 'send_to_segments' || ! $campaign->send_to_all) ? '' : 'hide' }}">
                     @forelse($segments as $segment)
                         <div class="checkbox">
                             <label>
@@ -105,8 +109,12 @@
                 <div class="form-group row form-group-schedule">
                     <div class="col-sm-12">
                         <select id="id-field-schedule" class="form-control" name="schedule">
-                            <option value="now">{{ __('Dispatch now') }}</option>
-                            <option value="scheduled">{{ __('Dispatch at a specific time') }}</option>
+                            <option value="now" {{ old('schedule') === 'now' || is_null($campaign->scheduled_at) ? 'selected' : '' }}>
+                                {{ __('Dispatch now') }}
+                            </option>
+                            <option value="scheduled" {{ old('schedule') === 'now' || $campaign->scheduled_at ? 'selected' : '' }}>
+                                {{ __('Dispatch at a specific time') }}
+                            </option>
                         </select>
                     </div>
                 </div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -30,6 +30,7 @@ Route::middleware([
     config('sendportal.throttle_middleware'),
 ])->name('sendportal.api.')->namespace('Api')->prefix('workspaces/{workspaceId}')->group(static function (Router $apiRouter) {
     $apiRouter->apiResource('campaigns', 'CampaignsController');
+    $apiRouter->post('campaigns/{id}/send', 'CampaignDispatchController@send');
     $apiRouter->apiResource('subscribers', 'SubscribersController');
     $apiRouter->apiResource('segments', 'SegmentsController');
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -30,7 +30,7 @@ Route::middleware([
     config('sendportal.throttle_middleware'),
 ])->name('sendportal.api.')->namespace('Api')->prefix('workspaces/{workspaceId}')->group(static function (Router $apiRouter) {
     $apiRouter->apiResource('campaigns', 'CampaignsController');
-    $apiRouter->post('campaigns/{id}/send', 'CampaignDispatchController@send');
+    $apiRouter->post('campaigns/{id}/send', 'CampaignDispatchController@send')->name('campaigns.send');
     $apiRouter->apiResource('subscribers', 'SubscribersController');
     $apiRouter->apiResource('segments', 'SegmentsController');
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -29,6 +29,7 @@ Route::middleware([
     VerifyUserOnWorkspace::class,
     config('sendportal.throttle_middleware'),
 ])->name('sendportal.api.')->namespace('Api')->prefix('workspaces/{workspaceId}')->group(static function (Router $apiRouter) {
+    $apiRouter->apiResource('campaigns', 'CampaignsController');
     $apiRouter->apiResource('subscribers', 'SubscribersController');
     $apiRouter->apiResource('segments', 'SegmentsController');
 

--- a/src/Http/Controllers/Api/CampaignDispatchController.php
+++ b/src/Http/Controllers/Api/CampaignDispatchController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Sendportal\Base\Http\Controllers\Api;
+
+use Sendportal\Base\Http\Controllers\Controller;
+use Sendportal\Base\Http\Requests\Api\CampaignDispatchRequest;
+use Sendportal\Base\Http\Resources\Campaign as CampaignResource;
+use Sendportal\Base\Interfaces\QuotaServiceInterface;
+use Sendportal\Base\Models\CampaignStatus;
+use Sendportal\Base\Repositories\Campaigns\CampaignTenantRepositoryInterface;
+
+class CampaignDispatchController extends Controller
+{
+    /**
+     * @var CampaignTenantRepositoryInterface
+     */
+    protected $campaigns;
+
+    /**
+     * @var QuotaServiceInterface
+     */
+    protected $quotaService;
+
+    public function __construct(
+        CampaignTenantRepositoryInterface $campaigns,
+        QuotaServiceInterface $quotaService
+    )
+    {
+        $this->campaigns = $campaigns;
+        $this->quotaService = $quotaService;
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function send(CampaignDispatchRequest $request, $workspaceId, $campaignId)
+    {
+        $campaign = $request->getCampaign();
+
+        if ($this->quotaService->exceedsQuota($campaign)) {
+            return response([
+                'message' => __('The number of subscribers for this campaign exceeds your SES quota')
+            ], 422);
+        }
+
+        $campaign = $this->campaigns->update($workspaceId, $campaignId, [
+            'status_id' => CampaignStatus::STATUS_QUEUED,
+        ]);
+
+        return new CampaignResource($campaign);
+    }
+}

--- a/src/Http/Controllers/Api/CampaignsController.php
+++ b/src/Http/Controllers/Api/CampaignsController.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sendportal\Base\Http\Controllers\Api;
+
+use Exception;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Response;
+use Sendportal\Base\Http\Controllers\Controller;
+use Sendportal\Base\Http\Requests\CampaignStoreRequest;
+use Sendportal\Base\Http\Resources\Campaign as CampaignResource;
+use Sendportal\Base\Repositories\Campaigns\CampaignTenantRepositoryInterface;
+
+class CampaignsController extends Controller
+{
+    /** @var CampaignTenantRepositoryInterface */
+    private $campaigns;
+
+    public function __construct(CampaignTenantRepositoryInterface $campaigns)
+    {
+        $this->campaigns = $campaigns;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function index(int $workspaceId): CampaignResource
+    {
+        return CampaignResource::collection($this->campaigns->paginate($workspaceId, 'id', ['segments']));
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function store(CampaignStoreRequest $request, int $workspaceId): CampaignResource
+    {
+        $input = $request->validated();
+
+        $campaign = $this->campaigns->store($workspaceId, collect($input));
+
+        return new CampaignResource($campaign);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function show(int $workspaceId, int $id): CampaignResource
+    {
+        $campaign = $this->campaigns->find($workspaceId, $id);
+
+        return new CampaignResource($campaign);
+    }
+}

--- a/src/Http/Controllers/Api/CampaignsController.php
+++ b/src/Http/Controllers/Api/CampaignsController.php
@@ -6,7 +6,6 @@ namespace Sendportal\Base\Http\Controllers\Api;
 
 use Exception;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
-use Illuminate\Http\Response;
 use Sendportal\Base\Http\Controllers\Controller;
 use Sendportal\Base\Http\Requests\CampaignStoreRequest;
 use Sendportal\Base\Http\Resources\Campaign as CampaignResource;
@@ -46,6 +45,16 @@ class CampaignsController extends Controller
     public function show(int $workspaceId, int $id): CampaignResource
     {
         $campaign = $this->campaigns->find($workspaceId, $id);
+
+        return new CampaignResource($campaign);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function update(CampaignStoreRequest $request, int $workspaceId, int $id): CampaignResource
+    {
+        $campaign = $this->campaigns->update($workspaceId, $id, $request->validated());
 
         return new CampaignResource($campaign);
     }

--- a/src/Http/Controllers/Api/CampaignsController.php
+++ b/src/Http/Controllers/Api/CampaignsController.php
@@ -6,8 +6,9 @@ namespace Sendportal\Base\Http\Controllers\Api;
 
 use Exception;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Support\Arr;
 use Sendportal\Base\Http\Controllers\Controller;
-use Sendportal\Base\Http\Requests\CampaignStoreRequest;
+use Sendportal\Base\Http\Requests\Api\CampaignStoreRequest;
 use Sendportal\Base\Http\Resources\Campaign as CampaignResource;
 use Sendportal\Base\Repositories\Campaigns\CampaignTenantRepositoryInterface;
 
@@ -34,7 +35,14 @@ class CampaignsController extends Controller
      */
     public function store(CampaignStoreRequest $request, int $workspaceId): CampaignResource
     {
-        $campaign = $this->campaigns->store($workspaceId, $request->validated());
+        $data = Arr::except($request->validated(), ['recipients', 'segments']);
+
+        $data['send_to_all'] = $request->get('recipients') === 'send_to_all';
+        $data['save_as_draft'] = $request->get('save_as_draft') ?? 0;
+
+        $campaign = $this->campaigns->store($workspaceId, $data);
+
+        $campaign->segments()->sync($request->get('segments'));
 
         return new CampaignResource($campaign);
     }
@@ -54,7 +62,14 @@ class CampaignsController extends Controller
      */
     public function update(CampaignStoreRequest $request, int $workspaceId, int $id): CampaignResource
     {
-        $campaign = $this->campaigns->update($workspaceId, $id, $request->validated());
+        $data = Arr::except($request->validated(), ['recipients', 'segments']);
+
+        $data['send_to_all'] = $request->get('recipients') === 'send_to_all';
+        $data['save_as_draft'] = $request->get('save_as_draft') ?? 0;
+
+        $campaign = $this->campaigns->update($workspaceId, $id, $data);
+
+        $campaign->segments()->sync($request->get('segments'));
 
         return new CampaignResource($campaign);
     }

--- a/src/Http/Controllers/Api/CampaignsController.php
+++ b/src/Http/Controllers/Api/CampaignsController.php
@@ -25,7 +25,7 @@ class CampaignsController extends Controller
     /**
      * @throws Exception
      */
-    public function index(int $workspaceId): CampaignResource
+    public function index(int $workspaceId): AnonymousResourceCollection
     {
         return CampaignResource::collection($this->campaigns->paginate($workspaceId, 'id', ['segments']));
     }
@@ -35,9 +35,7 @@ class CampaignsController extends Controller
      */
     public function store(CampaignStoreRequest $request, int $workspaceId): CampaignResource
     {
-        $input = $request->validated();
-
-        $campaign = $this->campaigns->store($workspaceId, collect($input));
+        $campaign = $this->campaigns->store($workspaceId, $request->validated());
 
         return new CampaignResource($campaign);
     }

--- a/src/Http/Controllers/Api/CampaignsController.php
+++ b/src/Http/Controllers/Api/CampaignsController.php
@@ -35,9 +35,8 @@ class CampaignsController extends Controller
      */
     public function store(CampaignStoreRequest $request, int $workspaceId): CampaignResource
     {
-        $data = Arr::except($request->validated(), ['recipients', 'segments']);
+        $data = Arr::except($request->validated(), ['segments']);
 
-        $data['send_to_all'] = $request->get('recipients') === 'send_to_all';
         $data['save_as_draft'] = $request->get('save_as_draft') ?? 0;
 
         $campaign = $this->campaigns->store($workspaceId, $data);
@@ -62,9 +61,8 @@ class CampaignsController extends Controller
      */
     public function update(CampaignStoreRequest $request, int $workspaceId, int $id): CampaignResource
     {
-        $data = Arr::except($request->validated(), ['recipients', 'segments']);
+        $data = Arr::except($request->validated(), ['segments']);
 
-        $data['send_to_all'] = $request->get('recipients') === 'send_to_all';
         $data['save_as_draft'] = $request->get('save_as_draft') ?? 0;
 
         $campaign = $this->campaigns->update($workspaceId, $id, $data);

--- a/src/Http/Controllers/Campaigns/CampaignDispatchController.php
+++ b/src/Http/Controllers/Campaigns/CampaignDispatchController.php
@@ -40,7 +40,7 @@ class CampaignDispatchController extends Controller
     {
         $campaign = $this->campaigns->find(auth()->user()->currentWorkspace()->id, $id, ['email_service']);
 
-        if ($campaign->status_id > CampaignStatus::STATUS_DRAFT) {
+        if ($campaign->status_id !== CampaignStatus::STATUS_DRAFT) {
             return redirect()->route('sendportal.campaigns.status', $id);
         }
 

--- a/src/Http/Requests/Api/CampaignDispatchRequest.php
+++ b/src/Http/Requests/Api/CampaignDispatchRequest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sendportal\Base\Http\Requests\Api;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Validator;
+use Sendportal\Base\Models\Campaign;
+use Sendportal\Base\Models\CampaignStatus;
+use Sendportal\Base\Repositories\Campaigns\CampaignTenantRepositoryInterface;
+
+class CampaignDispatchRequest extends FormRequest
+{
+    /**
+     * @var CampaignTenantRepositoryInterface
+     */
+    protected $campaigns;
+
+    /**
+     * @var Campaign
+     */
+    protected $campaign;
+
+    public function __construct(CampaignTenantRepositoryInterface $campaigns)
+    {
+        parent::__construct();
+
+        $this->campaigns = $campaigns;
+
+        Validator::extendImplicit('valid_status', function ($attribute, $value, $parameters, $validator) {
+            return $this->getCampaign()->status_id === CampaignStatus::STATUS_DRAFT;
+        });
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function getCampaign(): Campaign
+    {
+        return $this->campaign = $this->campaigns->find($this->workspaceId, $this->id);
+    }
+
+    public function rules()
+    {
+        return [
+            'status_id' => 'valid_status',
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'valid_status' => __('The campaign must have a status of draft to be dispatched'),
+        ];
+    }
+}

--- a/src/Http/Requests/Api/CampaignStoreRequest.php
+++ b/src/Http/Requests/Api/CampaignStoreRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sendportal\Base\Http\Requests\Api;
+
+use Illuminate\Validation\Rule;
+use Sendportal\Base\Http\Requests\CampaignStoreRequest as BaseCampaignStoreRequest;
+
+class CampaignStoreRequest extends BaseCampaignStoreRequest
+{
+    public function rules(): array
+    {
+        $rules = [
+            'recipients' => [
+                'required',
+                Rule::in(['send_to_all', 'send_to_segments']),
+            ],
+            'segments' => [
+                'required_unless:recipients,send_to_all',
+                'array',
+            ],
+            'segments.*' => [
+                'integer',
+                'exists:segments,id'
+            ],
+            'scheduled_at' => [
+                'nullable',
+                'datetime',
+            ],
+            'save_as_draft' => [
+                'nullable',
+                'boolean',
+            ],
+        ];
+
+        return array_merge($this->getRules(), $rules);
+    }
+}

--- a/src/Http/Requests/Api/CampaignStoreRequest.php
+++ b/src/Http/Requests/Api/CampaignStoreRequest.php
@@ -12,12 +12,12 @@ class CampaignStoreRequest extends BaseCampaignStoreRequest
     public function rules(): array
     {
         $rules = [
-            'recipients' => [
+            'send_to_all' => [
                 'required',
-                Rule::in(['send_to_all', 'send_to_segments']),
+                'boolean',
             ],
             'segments' => [
-                'required_unless:recipients,send_to_all',
+                'required_unless:send_to_all,1',
                 'array',
             ],
             'segments.*' => [

--- a/src/Http/Requests/Api/CampaignStoreRequest.php
+++ b/src/Http/Requests/Api/CampaignStoreRequest.php
@@ -24,8 +24,8 @@ class CampaignStoreRequest extends BaseCampaignStoreRequest
                 'exists:segments,id'
             ],
             'scheduled_at' => [
-                'nullable',
-                'datetime',
+                'required',
+                'date',
             ],
             'save_as_draft' => [
                 'nullable',

--- a/src/Http/Requests/Api/CampaignStoreRequest.php
+++ b/src/Http/Requests/Api/CampaignStoreRequest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Sendportal\Base\Http\Requests\Api;
 
-use Illuminate\Validation\Rule;
 use Sendportal\Base\Http\Requests\CampaignStoreRequest as BaseCampaignStoreRequest;
 
 class CampaignStoreRequest extends BaseCampaignStoreRequest

--- a/src/Http/Requests/Api/CampaignStoreRequest.php
+++ b/src/Http/Requests/Api/CampaignStoreRequest.php
@@ -4,10 +4,40 @@ declare(strict_types=1);
 
 namespace Sendportal\Base\Http\Requests\Api;
 
+use Illuminate\Support\Facades\Validator;
 use Sendportal\Base\Http\Requests\CampaignStoreRequest as BaseCampaignStoreRequest;
+use Sendportal\Base\Models\Campaign;
+use Sendportal\Base\Models\CampaignStatus;
+use Sendportal\Base\Repositories\Campaigns\CampaignTenantRepositoryInterface;
 
 class CampaignStoreRequest extends BaseCampaignStoreRequest
 {
+    /**
+     * @var CampaignTenantRepositoryInterface
+     */
+    protected $campaigns;
+
+    public function __construct(CampaignTenantRepositoryInterface $campaigns)
+    {
+        parent::__construct();
+
+        $this->campaigns = $campaigns;
+
+        Validator::extendImplicit('valid_status', function ($attribute, $value, $parameters, $validator) {
+            return $this->campaign
+                ? $this->getCampaign()->status_id === CampaignStatus::STATUS_DRAFT
+                : true;
+        });
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function getCampaign(): Campaign
+    {
+        return $this->campaign = $this->campaigns->find($this->workspaceId, $this->campaign);
+    }
+
     public function rules(): array
     {
         $rules = [
@@ -31,8 +61,16 @@ class CampaignStoreRequest extends BaseCampaignStoreRequest
                 'nullable',
                 'boolean',
             ],
+            'status_id' => 'valid_status',
         ];
 
         return array_merge($this->getRules(), $rules);
+    }
+
+    public function messages(): array
+    {
+        return [
+            'valid_status' => __('A campaign cannot be updated if its status is not draft'),
+        ];
     }
 }

--- a/src/Http/Requests/CampaignStoreRequest.php
+++ b/src/Http/Requests/CampaignStoreRequest.php
@@ -11,6 +11,14 @@ class CampaignStoreRequest extends FormRequest
 {
     public function rules(): array
     {
+        return $this->getRules();
+    }
+
+    /**
+     * @return array
+     */
+    protected function getRules(): array
+    {
         return [
             'name' => [
                 'required',

--- a/src/Http/Resources/Campaign.php
+++ b/src/Http/Resources/Campaign.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Sendportal\Base\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class Campaign extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'subject' => $this->subject,
+            'status_id' => $this->status_id,
+            'template_id' => $this->template_id,
+            'email_service_id' => $this->email_service_id,
+            'from_name' => $this->from_name,
+            'from_email' => $this->from_email,
+            'is_open_tracking' => $this->is_open_tracking,
+            'is_click_tracking' => $this->is_click_tracking,
+            'sent_count' => $this->sent_count,
+            'open_count' => $this->open_count,
+            'click_count' => $this->click_count,
+            'send_to_all' => $this->send_to_all,
+            'segments' => $this->whenLoaded('segments', $this->segments->modelKeys()),
+            'save_as_draft' => $this->save_as_draft,
+            'scheduled_at' => $this->scheduled_at->toDateTimeString(),
+            'created_at' => $this->created_at->toDateTimeString(),
+            'update_at' => $this->updated_at->toDateTimeString()
+        ];
+    }
+}

--- a/src/Http/Resources/Campaign.php
+++ b/src/Http/Resources/Campaign.php
@@ -31,7 +31,7 @@ class Campaign extends JsonResource
             'send_to_all' => $this->send_to_all,
             'segments' => $this->whenLoaded('segments', $this->segments->modelKeys()),
             'save_as_draft' => $this->save_as_draft,
-            'scheduled_at' => $this->scheduled_at->toDateTimeString(),
+            'scheduled_at' => $this->scheduled_at ? $this->scheduled_at->toDateTimeString() : null,
             'created_at' => $this->created_at->toDateTimeString(),
             'update_at' => $this->updated_at->toDateTimeString()
         ];

--- a/src/Http/Resources/Campaign.php
+++ b/src/Http/Resources/Campaign.php
@@ -18,6 +18,7 @@ class Campaign extends JsonResource
             'id' => $this->id,
             'name' => $this->name,
             'subject' => $this->subject,
+            'content' => $this->content,
             'status_id' => $this->status_id,
             'template_id' => $this->template_id,
             'email_service_id' => $this->email_service_id,

--- a/src/Http/Resources/Campaign.php
+++ b/src/Http/Resources/Campaign.php
@@ -34,7 +34,7 @@ class Campaign extends JsonResource
             'save_as_draft' => $this->save_as_draft,
             'scheduled_at' => $this->scheduled_at ? $this->scheduled_at->toDateTimeString() : null,
             'created_at' => $this->created_at->toDateTimeString(),
-            'update_at' => $this->updated_at->toDateTimeString()
+            'updated_at' => $this->updated_at->toDateTimeString()
         ];
     }
 }

--- a/src/Models/Campaign.php
+++ b/src/Models/Campaign.php
@@ -24,6 +24,7 @@ class Campaign extends BaseModel
         'is_click_tracking' => 'bool',
         'scheduled_at' => 'datetime',
         'save_as_draft' => 'bool',
+        'send_to_all' => 'bool',
     ];
 
     /**

--- a/src/Models/Campaign.php
+++ b/src/Models/Campaign.php
@@ -21,7 +21,8 @@ class Campaign extends BaseModel
     /** @var array */
     protected $casts = [
         'is_open_tracking' => 'bool',
-        'is_click_tracking' => 'bool'
+        'is_click_tracking' => 'bool',
+        'scheduled_at' => 'datetime',
     ];
 
     /**

--- a/src/Models/Campaign.php
+++ b/src/Models/Campaign.php
@@ -23,6 +23,7 @@ class Campaign extends BaseModel
         'is_open_tracking' => 'bool',
         'is_click_tracking' => 'bool',
         'scheduled_at' => 'datetime',
+        'save_as_draft' => 'bool',
     ];
 
     /**

--- a/tests/Feature/API/CampaignDispatchControllerTest.php
+++ b/tests/Feature/API/CampaignDispatchControllerTest.php
@@ -5,84 +5,103 @@ declare(strict_types=1);
 namespace Tests\Feature\API;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Validation\ValidationException;
+use Mockery;
 use Sendportal\Base\Interfaces\QuotaServiceInterface;
 use Sendportal\Base\Models\Campaign;
 use Sendportal\Base\Models\CampaignStatus;
+use Sendportal\Base\Models\EmailService;
+use Sendportal\Base\Models\EmailServiceType;
+use Sendportal\Base\Models\Workspace;
+use Sendportal\Base\Services\QuotaService;
+use Symfony\Component\HttpFoundation\Response;
 use Tests\TestCase;
 
 class CampaignDispatchControllerTest extends TestCase
 {
-    use RefreshDatabase,
-        WithFaker;
-
-    /**
-     * @return void
-     */
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        $quotaService = $this->getMockBuilder(QuotaServiceInterface::class)->getMock();
-
-        $quotaService->method('exceedsQuota')->willReturn(false);
-
-        $this->app->instance(QuotaServiceInterface::class, $quotaService);
-    }
+    use RefreshDatabase;
 
     /** @test */
     public function a_draft_campaign_can_be_dispatched()
     {
+        $this->ignoreQuota();
+
         [$workspace, $emailService] = $this->createUserWithWorkspaceAndEmailService();
 
-        $campaign = factory(Campaign::class)->states('draft')->create(
-            [
-                'workspace_id' => $workspace->id,
-                'email_service_id' => $emailService->id,
-            ]
-        );
-
-        $route = route('sendportal.api.campaigns.send', [
-            'workspaceId' => $workspace->id,
-            'id' => $campaign->id,
-            'api_token' => $workspace->owner->api_token,
+        $campaign = factory(Campaign::class)->states('draft')->create([
+            'workspace_id' => $workspace->id,
+            'email_service_id' => $emailService->id,
         ]);
 
-        $response = $this->post($route);
-
-        $response->assertStatus(200);
-
-        $expected = [
-            'data' => [
-                'status_id' => CampaignStatus::STATUS_QUEUED,
-            ],
-        ];
-
-        $response->assertJson($expected);
+        $this
+            ->postJson(route('sendportal.api.campaigns.send', [
+                'workspaceId' => $workspace->id,
+                'id' => $campaign->id,
+                'api_token' => $workspace->owner->api_token,
+            ]))
+            ->assertOk()
+            ->assertJson([
+                'data' => [
+                    'status_id' => CampaignStatus::STATUS_QUEUED,
+                ],
+            ]);
     }
 
     /** @test */
     public function a_sent_campaign_cannot_be_dispatched()
     {
+        $this->ignoreQuota();
+
         [$workspace, $emailService] = $this->createUserWithWorkspaceAndEmailService();
 
         $campaign = $this->createCampaign($workspace, $emailService);
 
-        $route = route('sendportal.api.campaigns.send', [
-            'workspaceId' => $workspace->id,
-            'id' => $campaign->id,
-            'api_token' => $workspace->owner->api_token,
+        $this
+            ->postJson(route('sendportal.api.campaigns.send', [
+                'workspaceId' => $workspace->id,
+                'id' => $campaign->id,
+                'api_token' => $workspace->owner->api_token,
+            ]))
+            ->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY)
+            ->assertJsonValidationErrors([
+                'status_id' => 'The campaign must have a status of draft to be dispatched'
+            ]);
+    }
+
+    /** @test */
+    public function a_campaign_cannot_be_dispatched_if_the_number_of_subscribers_exceeds_the_ses_quota()
+    {
+        $this->instance(QuotaServiceInterface::class, Mockery::mock(QuotaService::class, function ($mock) {
+            $mock->shouldReceive('exceedsQuota')->andReturn(true);
+        }));
+
+        $workspace = factory(Workspace::class)->create();
+
+        $emailService = factory(EmailService::class)->create([
+            'workspace_id' => $workspace->id,
+            'type_id' => EmailServiceType::SES
         ]);
 
-        $this->expectException(ValidationException::class);
+        $campaign = factory(Campaign::class)->states('draft')->create([
+            'workspace_id' => $workspace->id,
+            'email_service_id' => $emailService->id,
+        ]);
 
-        $response = $this->post($route);
+        $this
+            ->postJson(route('sendportal.api.campaigns.send', [
+                'workspaceId' => $workspace->id,
+                'id' => $campaign->id,
+                'api_token' => $workspace->owner->api_token,
+            ]))
+            ->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY)
+            ->assertJson([
+                'message' => 'The number of subscribers for this campaign exceeds your SES quota'
+            ]);
+    }
 
-        $expected = [
-            'message' => __('The campaign must have a status of draft to be dispatched'),
-        ];
-
-        $response->assertJson($expected);
+    protected function ignoreQuota()
+    {
+        $this->instance(QuotaServiceInterface::class, Mockery::mock(QuotaService::class, function ($mock) {
+            $mock->shouldReceive('exceedsQuota')->andReturn(false);
+        }));
     }
 }

--- a/tests/Feature/API/CampaignDispatchControllerTest.php
+++ b/tests/Feature/API/CampaignDispatchControllerTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\API;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Validation\ValidationException;
+use Sendportal\Base\Interfaces\QuotaServiceInterface;
+use Sendportal\Base\Models\Campaign;
+use Sendportal\Base\Models\CampaignStatus;
+use Tests\TestCase;
+
+class CampaignDispatchControllerTest extends TestCase
+{
+    use RefreshDatabase,
+        WithFaker;
+
+    /**
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $quotaService = $this->getMockBuilder(QuotaServiceInterface::class)->getMock();
+
+        $quotaService->method('exceedsQuota')->willReturn(false);
+
+        $this->app->instance(QuotaServiceInterface::class, $quotaService);
+    }
+
+    /** @test */
+    public function a_draft_campaign_can_be_dispatched()
+    {
+        [$workspace, $emailService] = $this->createUserWithWorkspaceAndEmailService();
+
+        $campaign = factory(Campaign::class)->states('draft')->create(
+            [
+                'workspace_id' => $workspace->id,
+                'email_service_id' => $emailService->id,
+            ]
+        );
+
+        $route = route('sendportal.api.campaigns.send', [
+            'workspaceId' => $workspace->id,
+            'id' => $campaign->id,
+            'api_token' => $workspace->owner->api_token,
+        ]);
+
+        $response = $this->post($route);
+
+        $response->assertStatus(200);
+
+        $expected = [
+            'data' => [
+                'status_id' => CampaignStatus::STATUS_QUEUED,
+            ],
+        ];
+
+        $response->assertJson($expected);
+    }
+
+    /** @test */
+    public function a_sent_campaign_cannot_be_dispatched()
+    {
+        [$workspace, $emailService] = $this->createUserWithWorkspaceAndEmailService();
+
+        $campaign = $this->createCampaign($workspace, $emailService);
+
+        $route = route('sendportal.api.campaigns.send', [
+            'workspaceId' => $workspace->id,
+            'id' => $campaign->id,
+            'api_token' => $workspace->owner->api_token,
+        ]);
+
+        $this->expectException(ValidationException::class);
+
+        $response = $this->post($route);
+
+        $expected = [
+            'message' => __('The campaign must have a status of draft to be dispatched'),
+        ];
+
+        $response->assertJson($expected);
+    }
+}

--- a/tests/Feature/API/CampaignsControllerTest.php
+++ b/tests/Feature/API/CampaignsControllerTest.php
@@ -78,6 +78,7 @@ class CampaignsControllerTest extends TestCase
             'email_service_id' => $emailService->id,
             'content' => $this->faker->sentence,
             'send_to_all' => 1,
+            'scheduled_at' => now(),
         ];
 
         $response = $this->post($route, array_merge($request, ['api_token' => $workspace->owner->api_token]));
@@ -110,6 +111,7 @@ class CampaignsControllerTest extends TestCase
             'email_service_id' => $emailService->id,
             'content' => $this->faker->sentence,
             'send_to_all' => 1,
+            'scheduled_at' => now(),
         ];
 
         $response = $this->put($route, $request);

--- a/tests/Feature/API/CampaignsControllerTest.php
+++ b/tests/Feature/API/CampaignsControllerTest.php
@@ -77,7 +77,7 @@ class CampaignsControllerTest extends TestCase
             'from_email' => $this->faker->safeEmail,
             'email_service_id' => $emailService->id,
             'content' => $this->faker->sentence,
-            'recipients' => 'send_to_all',
+            'send_to_all' => 1,
         ];
 
         $response = $this->post($route, array_merge($request, ['api_token' => $workspace->owner->api_token]));
@@ -109,7 +109,7 @@ class CampaignsControllerTest extends TestCase
             'from_email' => $this->faker->safeEmail,
             'email_service_id' => $emailService->id,
             'content' => $this->faker->sentence,
-            'recipients' => 'send_to_all',
+            'send_to_all' => 1,
         ];
 
         $response = $this->put($route, $request);

--- a/tests/Feature/API/CampaignsControllerTest.php
+++ b/tests/Feature/API/CampaignsControllerTest.php
@@ -15,15 +15,15 @@ class CampaignsControllerTest extends TestCase
         WithFaker;
 
     /** @test */
-    public function a_list_of_a_workspaces_campaigns_can_be_retreived()
+    public function a_list_of_a_workspaces_campaigns_can_be_retrieved()
     {
-        $user = $this->createUserWithWorkspace();
+        [$workspace, $emailService] = $this->createUserWithWorkspaceAndEmailService();
 
-        $campaign = $this->createCampaign($user);
+        $campaign = $this->createCampaign($workspace, $emailService);
 
         $route = route('sendportal.api.campaigns.index', [
-            'workspaceId' => $user->currentWorkspace()->id,
-            'api_token' => $user->api_token,
+            'workspaceId' => $workspace->id,
+            'api_token' => $workspace->owner->api_token,
         ]);
 
         $response = $this->get($route);
@@ -40,16 +40,16 @@ class CampaignsControllerTest extends TestCase
     }
 
     /** @test */
-    public function a_single_campaign_can_be_retreived()
+    public function a_single_campaign_can_be_retrieved()
     {
-        $user = $this->createUserWithWorkspace();
+        [$workspace, $emailService] = $this->createUserWithWorkspaceAndEmailService();
 
-        $campaign = $this->createCampaign($user);
+        $campaign = $this->createCampaign($workspace, $emailService);
 
         $route = route('sendportal.api.campaigns.show', [
-            'workspaceId' => $user->currentWorkspace()->id,
+            'workspaceId' => $workspace->id,
             'campaign' => $campaign->id,
-            'api_token' => $user->api_token,
+            'api_token' => $workspace->owner->api_token,
         ]);
 
         $response = $this->get($route);
@@ -66,15 +66,20 @@ class CampaignsControllerTest extends TestCase
     /** @test */
     public function a_new_campaign_can_be_added()
     {
-        $user = $this->createUserWithWorkspace();
+        [$workspace, $emailService] = $this->createUserWithWorkspaceAndEmailService();
 
-        $route = route('sendportal.api.campaigns.store', $user->currentWorkspace()->id);
+        $route = route('sendportal.api.campaigns.store', $workspace->id);
 
         $request = [
             'name' => $this->faker->colorName,
+            'subject' => $this->faker->word,
+            'from_name' => $this->faker->word,
+            'from_email' => $this->faker->safeEmail,
+            'email_service_id' => $emailService->id,
+            'content' => $this->faker->sentence,
         ];
 
-        $response = $this->post($route, array_merge($request, ['api_token' => $user->api_token]));
+        $response = $this->post($route, array_merge($request, ['api_token' => $workspace->owner->api_token]));
 
         $response->assertStatus(201);
         $this->assertDatabaseHas('campaigns', $request);

--- a/tests/Feature/API/CampaignsControllerTest.php
+++ b/tests/Feature/API/CampaignsControllerTest.php
@@ -7,6 +7,8 @@ namespace Tests\Feature\API;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Arr;
+use Illuminate\Validation\ValidationException;
+use Sendportal\Base\Models\Campaign;
 use Tests\TestCase;
 
 class CampaignsControllerTest extends TestCase
@@ -83,15 +85,50 @@ class CampaignsControllerTest extends TestCase
 
         $response = $this->post($route, array_merge($request, ['api_token' => $workspace->owner->api_token]));
 
-        $data = Arr::except($request, 'recipients');
-
         $response->assertStatus(201);
-        $this->assertDatabaseHas('campaigns', $data);
-        $response->assertJson(['data' => $data]);
+        $this->assertDatabaseHas('campaigns', $request);
+        $response->assertJson(['data' => $request]);
     }
 
     /** @test */
     public function a_campaign_can_be_updated()
+    {
+        [$workspace, $emailService] = $this->createUserWithWorkspaceAndEmailService();
+
+        $campaign = factory(Campaign::class)->states('draft')->create(
+            [
+                'workspace_id' => $workspace->id,
+                'email_service_id' => $emailService->id,
+            ]
+        );
+
+        $route = route('sendportal.api.campaigns.update', [
+            'workspaceId' => $workspace->id,
+            'campaign' => $campaign->id,
+            'api_token' => $workspace->owner->api_token,
+        ]);
+
+        $request = [
+            'name' => $this->faker->word,
+            'subject' => $this->faker->word,
+            'from_name' => $this->faker->word,
+            'from_email' => $this->faker->safeEmail,
+            'email_service_id' => $emailService->id,
+            'content' => $this->faker->sentence,
+            'send_to_all' => 1,
+            'scheduled_at' => now(),
+        ];
+
+        $response = $this->put($route, $request);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseMissing('campaigns', $campaign->toArray());
+        $this->assertDatabaseHas('campaigns', $request);
+        $response->assertJson(['data' => $request]);
+    }
+
+    /** @test */
+    public function a_sent_campaign_cannot_be_updated()
     {
         [$workspace, $emailService] = $this->createUserWithWorkspaceAndEmailService();
 
@@ -114,13 +151,12 @@ class CampaignsControllerTest extends TestCase
             'scheduled_at' => now(),
         ];
 
+        $this->expectException(ValidationException::class);
+
         $response = $this->put($route, $request);
 
-        $data = Arr::except($request, 'recipients');
-
-        $response->assertStatus(200);
-        $this->assertDatabaseMissing('campaigns', $campaign->toArray());
-        $this->assertDatabaseHas('campaigns', $data);
-        $response->assertJson(['data' => $data]);
+        $this->assertDatabaseMissing('campaigns', $request);
+        $this->assertDatabaseHas('campaigns', $campaign->toArray());
+        $response->assertJson(['data' => ['message' => __('A campaign cannot be updated if its status is not draft')]]);
     }
 }

--- a/tests/Feature/API/CampaignsControllerTest.php
+++ b/tests/Feature/API/CampaignsControllerTest.php
@@ -85,4 +85,34 @@ class CampaignsControllerTest extends TestCase
         $this->assertDatabaseHas('campaigns', $request);
         $response->assertJson(['data' => $request]);
     }
+
+    /** @test */
+    public function a_campaign_can_be_updated()
+    {
+        [$workspace, $emailService] = $this->createUserWithWorkspaceAndEmailService();
+
+        $campaign = $this->createCampaign($workspace, $emailService);
+
+        $route = route('sendportal.api.campaigns.update', [
+            'workspaceId' => $workspace->id,
+            'campaign' => $campaign->id,
+            'api_token' => $workspace->owner->api_token,
+        ]);
+
+        $request = [
+            'name' => $this->faker->word,
+            'subject' => $this->faker->word,
+            'from_name' => $this->faker->word,
+            'from_email' => $this->faker->safeEmail,
+            'email_service_id' => $emailService->id,
+            'content' => $this->faker->sentence,
+        ];
+
+        $response = $this->put($route, $request);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseMissing('campaigns', $campaign->toArray());
+        $this->assertDatabaseHas('campaigns', $request);
+        $response->assertJson(['data' => $request]);
+    }
 }

--- a/tests/Feature/API/CampaignsControllerTest.php
+++ b/tests/Feature/API/CampaignsControllerTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\API;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Arr;
+use Tests\TestCase;
+
+class CampaignsControllerTest extends TestCase
+{
+    use RefreshDatabase,
+        WithFaker;
+
+    /** @test */
+    public function a_list_of_a_workspaces_campaigns_can_be_retreived()
+    {
+        $user = $this->createUserWithWorkspace();
+
+        $campaign = $this->createCampaign($user);
+
+        $route = route('sendportal.api.campaigns.index', [
+            'workspaceId' => $user->currentWorkspace()->id,
+            'api_token' => $user->api_token,
+        ]);
+
+        $response = $this->get($route);
+
+        $response->assertStatus(200);
+
+        $expected = [
+            'data' => [
+                Arr::only($campaign->toArray(), ['name'])
+            ],
+        ];
+
+        $response->assertJson($expected);
+    }
+
+    /** @test */
+    public function a_single_campaign_can_be_retreived()
+    {
+        $user = $this->createUserWithWorkspace();
+
+        $campaign = $this->createCampaign($user);
+
+        $route = route('sendportal.api.campaigns.show', [
+            'workspaceId' => $user->currentWorkspace()->id,
+            'campaign' => $campaign->id,
+            'api_token' => $user->api_token,
+        ]);
+
+        $response = $this->get($route);
+
+        $response->assertStatus(200);
+
+        $expected = [
+            'data' => Arr::only($campaign->toArray(), ['name']),
+        ];
+
+        $response->assertJson($expected);
+    }
+
+    /** @test */
+    public function a_new_campaign_can_be_added()
+    {
+        $user = $this->createUserWithWorkspace();
+
+        $route = route('sendportal.api.campaigns.store', $user->currentWorkspace()->id);
+
+        $request = [
+            'name' => $this->faker->colorName,
+        ];
+
+        $response = $this->post($route, array_merge($request, ['api_token' => $user->api_token]));
+
+        $response->assertStatus(201);
+        $this->assertDatabaseHas('campaigns', $request);
+        $response->assertJson(['data' => $request]);
+    }
+}

--- a/tests/Feature/API/CampaignsControllerTest.php
+++ b/tests/Feature/API/CampaignsControllerTest.php
@@ -77,13 +77,16 @@ class CampaignsControllerTest extends TestCase
             'from_email' => $this->faker->safeEmail,
             'email_service_id' => $emailService->id,
             'content' => $this->faker->sentence,
+            'recipients' => 'send_to_all',
         ];
 
         $response = $this->post($route, array_merge($request, ['api_token' => $workspace->owner->api_token]));
 
+        $data = Arr::except($request, 'recipients');
+
         $response->assertStatus(201);
-        $this->assertDatabaseHas('campaigns', $request);
-        $response->assertJson(['data' => $request]);
+        $this->assertDatabaseHas('campaigns', $data);
+        $response->assertJson(['data' => $data]);
     }
 
     /** @test */
@@ -106,13 +109,16 @@ class CampaignsControllerTest extends TestCase
             'from_email' => $this->faker->safeEmail,
             'email_service_id' => $emailService->id,
             'content' => $this->faker->sentence,
+            'recipients' => 'send_to_all',
         ];
 
         $response = $this->put($route, $request);
 
+        $data = Arr::except($request, 'recipients');
+
         $response->assertStatus(200);
         $this->assertDatabaseMissing('campaigns', $campaign->toArray());
-        $this->assertDatabaseHas('campaigns', $request);
-        $response->assertJson(['data' => $request]);
+        $this->assertDatabaseHas('campaigns', $data);
+        $response->assertJson(['data' => $data]);
     }
 }

--- a/tests/Feature/API/SegmentsControllerTest.php
+++ b/tests/Feature/API/SegmentsControllerTest.php
@@ -15,7 +15,7 @@ class SegmentsControllerTest extends TestCase
         WithFaker;
 
     /** @test */
-    public function a_list_of_a_workspaces_segments_can_be_retreived()
+    public function a_list_of_a_workspaces_segments_can_be_retrieved()
     {
         $user = $this->createUserWithWorkspace();
 
@@ -40,7 +40,7 @@ class SegmentsControllerTest extends TestCase
     }
 
     /** @test */
-    public function a_single_segment_can_be_retreived()
+    public function a_single_segment_can_be_retrieved()
     {
         $user = $this->createUserWithWorkspace();
 

--- a/tests/SendportalTestSupportTrait.php
+++ b/tests/SendportalTestSupportTrait.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use Illuminate\Testing\TestResponse;
 use Sendportal\Base\Models\Campaign;
+use Sendportal\Base\Models\EmailService;
 use Sendportal\Base\Models\Segment;
 use Sendportal\Base\Models\Subscriber;
 use Sendportal\Base\Models\User;
@@ -37,10 +38,24 @@ trait SendportalTestSupportTrait {
         auth()->login($user);
     }
 
-    protected function createCampaign(User $user): Campaign
+    protected function createUserWithWorkspaceAndEmailService(): array
     {
-        return factory(Campaign::class)->create([
-            'workspace_id' => $user->currentWorkspace()->id,
+        $user = factory(User::class)->create();
+        $workspace = factory(Workspace::class)->create([
+            'owner_id' => $user->id,
+        ]);
+        $emailService = factory(EmailService::class)->create([
+            'workspace_id' => $workspace->id,
+        ]);
+
+        return [$workspace, $emailService];
+    }
+
+    protected function createCampaign(Workspace $workspace, EmailService $emailService): Campaign
+    {
+        return factory(Campaign::class)->states(['withContent', 'sent'])->create([
+            'workspace_id' => $workspace->id,
+            'email_service_id' => $emailService->id,
         ]);
     }
 

--- a/tests/SendportalTestSupportTrait.php
+++ b/tests/SendportalTestSupportTrait.php
@@ -3,6 +3,7 @@
 namespace Tests;
 
 use Illuminate\Testing\TestResponse;
+use Sendportal\Base\Models\Campaign;
 use Sendportal\Base\Models\Segment;
 use Sendportal\Base\Models\Subscriber;
 use Sendportal\Base\Models\User;
@@ -34,6 +35,13 @@ trait SendportalTestSupportTrait {
     protected function loginUser(User $user): void
     {
         auth()->login($user);
+    }
+
+    protected function createCampaign(User $user): Campaign
+    {
+        return factory(Campaign::class)->create([
+            'workspace_id' => $user->currentWorkspace()->id,
+        ]);
     }
 
     protected function createSegment(User $user): Segment

--- a/tests/Unit/Models/CampaignTest.php
+++ b/tests/Unit/Models/CampaignTest.php
@@ -107,36 +107,6 @@ class CampaignTest extends TestCase
     }
 
     /**
-     * @return array
-     */
-    protected function createUserWithWorkspaceAndEmailService(): array
-    {
-        $user = factory(User::class)->create();
-        $workspace = factory(Workspace::class)->create([
-            'owner_id' => $user->id,
-        ]);
-        $emailService = factory(EmailService::class)->create([
-            'workspace_id' => $workspace->id,
-        ]);
-
-        return [$workspace, $emailService];
-    }
-
-    /**
-     * @param Workspace $workspace
-     * @param EmailService $emailService
-     *
-     * @return Campaign
-     */
-    protected function createCampaign(Workspace $workspace, EmailService $emailService): Campaign
-    {
-        return factory(Campaign::class)->states(['withContent', 'sent'])->create([
-            'workspace_id' => $workspace->id,
-            'email_service_id' => $emailService->id,
-        ]);
-    }
-
-    /**
      * @param Workspace $workspace
      * @param Campaign $campaign
      * @param int $quantity


### PR DESCRIPTION
### Story
https://www.notion.so/Ability-to-create-campaigns-via-the-API-2ca60ecd7c8448d7bca29e0fdab65758

### Description
Enable interaction with campaigns via API.