### PR TITLE
Include fromName as the display name

### DIFF
--- a/src/Adapters/MailgunMailAdapter.php
+++ b/src/Adapters/MailgunMailAdapter.php
@@ -20,7 +20,7 @@ class MailgunMailAdapter extends BaseMailAdapter
         'EU' => 'https://api.eu.mailgun.net/v3'
     ];
 
-    public function send(string $fromEmail, string $toEmail, string $subject, MessageTrackingOptions $trackingOptions, string $content): ?string
+    public function send(string $fromEmail, string $fromName, string $toEmail, string $subject, MessageTrackingOptions $trackingOptions, string $content): ?string
     {
         $parameters = [
             'from' => $fromEmail,

--- a/src/Adapters/PostmarkMailAdapter.php
+++ b/src/Adapters/PostmarkMailAdapter.php
@@ -14,7 +14,7 @@ class PostmarkMailAdapter extends BaseMailAdapter
     /** @var PostmarkClient */
     protected $client;
 
-    public function send(string $fromEmail, string $toEmail, string $subject, MessageTrackingOptions $trackingOptions, string $content): ?string
+    public function send(string $fromEmail, string $fromName, string $toEmail, string $subject, MessageTrackingOptions $trackingOptions, string $content): ?string
     {
         $result = $this->resolveClient()->sendEmail(
             $fromEmail,

--- a/src/Adapters/SendgridMailAdapter.php
+++ b/src/Adapters/SendgridMailAdapter.php
@@ -23,7 +23,7 @@ class SendgridMailAdapter extends BaseMailAdapter
     /**
      * @throws TypeException
      */
-    public function send(string $fromEmail, string $toEmail, string $subject, MessageTrackingOptions $trackingOptions, string $content): ?string
+    public function send(string $fromEmail, string $fromName, string $toEmail, string $subject, MessageTrackingOptions $trackingOptions, string $content): ?string
     {
         $email = new Mail();
         $email->setFrom($fromEmail);

--- a/src/Adapters/SesMailAdapter.php
+++ b/src/Adapters/SesMailAdapter.php
@@ -21,13 +21,13 @@ class SesMailAdapter extends BaseMailAdapter
     /**
      * @throws BindingResolutionException
      */
-    public function send(string $fromEmail, string $toEmail, string $subject, MessageTrackingOptions $trackingOptions, string $content): ?string
+    public function send(string $fromEmail, string $fromName, string $toEmail, string $subject, MessageTrackingOptions $trackingOptions, string $content): ?string
     {
         // TODO(david): It isn't clear whether it is possible to set per-message tracking for SES.
 
-        $result = $this->throttleSending(function () use ($fromEmail, $toEmail, $subject, $trackingOptions, $content) {
+        $result = $this->throttleSending(function () use ($fromEmail, $fromName, $toEmail, $subject, $trackingOptions, $content) {
             return $this->resolveClient()->sendEmail([
-                'Source' => $fromEmail,
+                'Source' => $fromName . ' <' . $fromEmail . '>',
 
                 'Destination' => [
                     'ToAddresses' => [$toEmail],

--- a/src/Interfaces/MailAdapterInterface.php
+++ b/src/Interfaces/MailAdapterInterface.php
@@ -10,6 +10,7 @@ interface MailAdapterInterface
      * Send an email.
      *
      * @param string $fromEmail
+     * @param string $fromName
      * @param string $toEmail
      * @param string $subject
      * @param MessageTrackingOptions $trackingOptions
@@ -17,5 +18,5 @@ interface MailAdapterInterface
      *
      * @return string
      */
-    public function send(string $fromEmail, string $toEmail, string $subject, MessageTrackingOptions $trackingOptions, string $content): ?string;
+    public function send(string $fromEmail, string $fromName, string $toEmail, string $subject, MessageTrackingOptions $trackingOptions, string $content): ?string;
 }

--- a/src/Services/Messages/DispatchMessage.php
+++ b/src/Services/Messages/DispatchMessage.php
@@ -78,6 +78,7 @@ class DispatchMessage
         $messageOptions = (new MessageOptions)
             ->setTo($message->recipient_email)
             ->setFrom($message->from_email)
+            ->setFromName($message->from_name)
             ->setSubject($message->subject)
             ->setTrackingOptions($trackingOptions);
 

--- a/src/Services/Messages/DispatchTestMessage.php
+++ b/src/Services/Messages/DispatchTestMessage.php
@@ -88,6 +88,7 @@ class DispatchTestMessage
         $messageOptions = (new MessageOptions)
             ->setTo($message->recipient_email)
             ->setFrom($message->from_email)
+            ->setFromName($message->from_name)
             ->setSubject($message->subject)
             ->setTrackingOptions($trackingOptions);
 

--- a/src/Services/Messages/MessageOptions.php
+++ b/src/Services/Messages/MessageOptions.php
@@ -11,6 +11,9 @@ class MessageOptions
 
     /** @var string */
     private $from;
+    
+    /** @var string */
+    private $fromName;
 
     /** @var string */
     private $subject;
@@ -44,6 +47,21 @@ class MessageOptions
     public function setFrom(string $from): self
     {
         $this->from = $from;
+
+        return $this;
+    }
+    
+    /**
+     * @return string
+     */
+    public function getFromName(): string
+    {
+        return $this->fromName;
+    }
+
+    public function setFrom(string $fromName): self
+    {
+        $this->fromName = $fromName;
 
         return $this;
     }

--- a/src/Services/Messages/RelayMessage.php
+++ b/src/Services/Messages/RelayMessage.php
@@ -28,6 +28,7 @@ class RelayMessage
         return $this->mailAdapter->adapter($emailService)
             ->send(
                 $messageOptions->getFrom(),
+                $messageOptions->getFromName(),
                 $messageOptions->getTo(),
                 $messageOptions->getSubject(),
                 $messageOptions->getTrackingOptions(),


### PR DESCRIPTION
The field 'from_name' is not used when sending emails via Amazon SES. This pull request addresses that by adding the from_name so the display name will show "Company Name <email@name.com>" per what is set in the campaign.