### PR TITLE
Feature/sqlite support

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,6 +27,7 @@
         <env name="SESSION_DRIVER" value="array"/>
         <env name="QUEUE_DRIVER" value="sync"/>
 
+        <env name="DB_CONNECTION" value="testing" />
         <env name="DB_DATABASE" value="sendportal_dev"/>
         <env name="DB_USERNAME" value="homestead"/>
         <env name="DB_PASSWORD" value="secret"/>

--- a/src/Models/Campaign.php
+++ b/src/Models/Campaign.php
@@ -20,6 +20,10 @@ class Campaign extends BaseModel
 
     /** @var array */
     protected $casts = [
+        'status_id' => 'int',
+        'workspace_id' => 'int',
+        'template_id' => 'int',
+        'email_service_id' => 'int',
         'is_open_tracking' => 'bool',
         'is_click_tracking' => 'bool'
     ];

--- a/src/Models/EmailService.php
+++ b/src/Models/EmailService.php
@@ -18,6 +18,13 @@ class EmailService extends BaseModel
         'settings',
     ];
 
+    /** @var array */
+    protected $casts = [
+        'id' => 'int',
+        'workspace_id' => 'int',
+        'type_id' => 'int'
+    ];
+
     /**
      * The type of this provider.
      */

--- a/src/Models/Invitation.php
+++ b/src/Models/Invitation.php
@@ -14,6 +14,12 @@ class Invitation extends Model
 
     protected $guarded = [];
 
+    /** @var array */
+    protected $casts = [
+        'user_id' => 'int',
+        'workspace_id' => 'int',
+    ];
+
     public function getExpiresAtAttribute(): Carbon
     {
         return $this->created_at->addWeek();

--- a/src/Presenters/CampaignReportPresenter.php
+++ b/src/Presenters/CampaignReportPresenter.php
@@ -290,15 +290,15 @@ class CampaignReportPresenter
 
         return [
             'counts' => [
-                'open' => $countData[$this->campaign->id]->opened,
-                'click' => $countData[$this->campaign->id]->clicked,
-                'sent' => $this->campaign->formatCount($countData[$this->campaign->id]->sent),
-                'bounce' => $countData[$this->campaign->id]->bounced,
+                'open' => (int) $countData[$this->campaign->id]->opened,
+                'click' => (int) $countData[$this->campaign->id]->clicked,
+                'sent' => $this->campaign->formatCount((int) $countData[$this->campaign->id]->sent),
+                'bounce' => (int) $countData[$this->campaign->id]->bounced,
             ],
             'ratios' => [
-                'open' => $this->campaign->getActionRatio($countData[$this->campaign->id]->opened, $countData[$this->campaign->id]->sent),
-                'click' => $this->campaign->getActionRatio($countData[$this->campaign->id]->clicked, $countData[$this->campaign->id]->sent),
-                'bounce' => $this->campaign->getActionRatio($countData[$this->campaign->id]->bounced, $countData[$this->campaign->id]->sent),
+                'open' => $this->campaign->getActionRatio((int) $countData[$this->campaign->id]->opened, (int) $countData[$this->campaign->id]->sent),
+                'click' => $this->campaign->getActionRatio((int) $countData[$this->campaign->id]->clicked, (int) $countData[$this->campaign->id]->sent),
+                'bounce' => $this->campaign->getActionRatio((int) $countData[$this->campaign->id]->bounced, (int) $countData[$this->campaign->id]->sent),
             ],
         ];
     }

--- a/src/Providers/SendportalAppServiceProvider.php
+++ b/src/Providers/SendportalAppServiceProvider.php
@@ -10,11 +10,14 @@ use Sendportal\Base\Interfaces\QuotaServiceInterface;
 use Sendportal\Base\Repositories\Campaigns\CampaignTenantRepositoryInterface;
 use Sendportal\Base\Repositories\Campaigns\MySqlCampaignTenantRepository;
 use Sendportal\Base\Repositories\Campaigns\PostgresCampaignTenantRepository;
+use Sendportal\Base\Repositories\Campaigns\SqliteCampaignTenantRepository;
 use Sendportal\Base\Repositories\Messages\MessageTenantRepositoryInterface;
 use Sendportal\Base\Repositories\Messages\MySqlMessageTenantRepository;
+use Sendportal\Base\Repositories\Messages\SqliteMessageTenantRepository;
 use Sendportal\Base\Repositories\Subscribers\MySqlSubscriberTenantRepository;
 use Sendportal\Base\Repositories\Messages\PostgresMessageTenantRepository;
 use Sendportal\Base\Repositories\Subscribers\PostgresSubscriberTenantRepository;
+use Sendportal\Base\Repositories\Subscribers\SqliteSubscriberTenantRepository;
 use Sendportal\Base\Repositories\Subscribers\SubscriberTenantRepositoryInterface;
 use Sendportal\Base\Services\Helper;
 use Sendportal\Base\Services\QuotaService;
@@ -37,7 +40,11 @@ class SendportalAppServiceProvider extends ServiceProvider
                 return $app->make(PostgresCampaignTenantRepository::class);
             }
 
-            return $app->make(MySqlCampaignTenantRepository::class);
+            if ($this->usingMySQL()) {
+                return $app->make(MySqlCampaignTenantRepository::class);
+            }
+
+            return $app->make(SqliteCampaignTenantRepository::class);
         });
 
         // Message repository.
@@ -46,7 +53,11 @@ class SendportalAppServiceProvider extends ServiceProvider
                 return $app->make(PostgresMessageTenantRepository::class);
             }
 
-            return $app->make(MySqlMessageTenantRepository::class);
+            if ($this->usingMySQL()) {
+                return $app->make(MySqlMessageTenantRepository::class);
+            }
+
+            return $app->make(SqliteMessageTenantRepository::class);
         });
 
         // Subscriber repository.
@@ -55,7 +66,11 @@ class SendportalAppServiceProvider extends ServiceProvider
                 return $app->make(PostgresSubscriberTenantRepository::class);
             }
 
-            return $app->make(MySqlSubscriberTenantRepository::class);
+            if ($this->usingMySQL()) {
+                return $app->make(MySqlSubscriberTenantRepository::class);
+            }
+
+            return $app->make(SqliteSubscriberTenantRepository::class);
         });
 
         $this->app->bind(QuotaServiceInterface::class, QuotaService::class);

--- a/src/Repositories/Campaigns/SqliteCampaignTenantRepository.php
+++ b/src/Repositories/Campaigns/SqliteCampaignTenantRepository.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sendportal\Base\Repositories\Campaigns;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Sendportal\Base\Models\Campaign;
+
+class SqliteCampaignTenantRepository extends BaseCampaignTenantRepository
+{
+    /**
+     * @inheritDoc
+     */
+    public function getAverageTimeToOpen(Campaign $campaign): string
+    {
+        $average = $campaign->opens()
+            ->selectRaw('ROUND(AVG(strftime("%s", opened_at) - strftime("%s", delivered_at))) as average_time_to_open')
+            ->value('average_time_to_open');
+
+        return $average ? $this->secondsToHms($average) : 'N/A';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getAverageTimeToClick(Campaign $campaign): string
+    {
+        $average = $campaign->clicks()
+            ->selectRaw('ROUND(AVG(strftime("%s", clicked_at) - strftime("%s", delivered_at))) as average_time_to_click')
+            ->value('average_time_to_click');
+
+        return $average ? $this->secondsToHms($average) : 'N/A';
+    }
+}

--- a/src/Repositories/Messages/MySqlMessageTenantRepository.php
+++ b/src/Repositories/Messages/MySqlMessageTenantRepository.php
@@ -13,12 +13,12 @@ class MySqlMessageTenantRepository extends BaseMessageTenantRepository
     public function countUniqueOpensPerPeriod(int $workspaceId, string $sourceType, int $sourceId, int $intervalInSeconds): Collection
     {
         return DB::table('messages')
-            ->select(DB::raw('COUNT(*) as open_count, MIN(opened_at) as opened_at, FROM_UNIXTIME(MIN(UNIX_TIMESTAMP(opened_at) DIV ' . $intervalInSeconds . ') * ' . $intervalInSeconds . ') as period_start'))
+            ->selectRaw('COUNT(*) as open_count, MIN(opened_at) as opened_at, FROM_UNIXTIME(MIN(UNIX_TIMESTAMP(opened_at) DIV ' . $intervalInSeconds . ') * ' . $intervalInSeconds . ') as period_start')
             ->where('workspace_id', $workspaceId)
             ->where('source_type', $sourceType)
             ->where('source_id', $sourceId)
             ->whereNotNull('opened_at')
-            ->groupBy(DB::raw('UNIX_TIMESTAMP(opened_at) DIV ' . $intervalInSeconds))
+            ->groupByRaw('UNIX_TIMESTAMP(opened_at) DIV ' . $intervalInSeconds)
             ->orderBy('opened_at')
             ->get();
     }

--- a/src/Repositories/Messages/SqliteMessageTenantRepository.php
+++ b/src/Repositories/Messages/SqliteMessageTenantRepository.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Sendportal\Base\Repositories\Messages;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class SqliteMessageTenantRepository extends BaseMessageTenantRepository
+{
+    /**
+     * @inheritDoc
+     */
+    public function countUniqueOpensPerPeriod(int $workspaceId, string $sourceType, int $sourceId, int $intervalInSeconds): Collection
+    {
+        $data = DB::table('messages')
+            ->select(DB::raw('COUNT(*) as open_count, MIN(opened_at) as opened_at, datetime(MIN(strftime("%s", opened_at) / ' . $intervalInSeconds . ') * ' . $intervalInSeconds . ', "unixepoch") as period_start'))
+            ->where('workspace_id', $workspaceId)
+            ->where('source_type', $sourceType)
+            ->where('source_id', $sourceId)
+            ->whereNotNull('opened_at')
+            ->groupBy(DB::raw('strftime("%s", opened_at) / ' . $intervalInSeconds))
+            ->orderBy('opened_at')
+            ->get();
+
+        return $data->map(function ($item, $k) {
+            $item->open_count = (int) $item->open_count;
+
+            return $item;
+        });
+    }
+}

--- a/src/Repositories/Messages/SqliteMessageTenantRepository.php
+++ b/src/Repositories/Messages/SqliteMessageTenantRepository.php
@@ -13,12 +13,12 @@ class SqliteMessageTenantRepository extends BaseMessageTenantRepository
     public function countUniqueOpensPerPeriod(int $workspaceId, string $sourceType, int $sourceId, int $intervalInSeconds): Collection
     {
         $data = DB::table('messages')
-            ->select(DB::raw('COUNT(*) as open_count, MIN(opened_at) as opened_at, datetime(MIN(strftime("%s", opened_at) / ' . $intervalInSeconds . ') * ' . $intervalInSeconds . ', "unixepoch") as period_start'))
+            ->selectRaw('COUNT(*) as open_count, MIN(opened_at) as opened_at, datetime(MIN(strftime("%s", opened_at) / ' . $intervalInSeconds . ') * ' . $intervalInSeconds . ', "unixepoch") as period_start')
             ->where('workspace_id', $workspaceId)
             ->where('source_type', $sourceType)
             ->where('source_id', $sourceId)
             ->whereNotNull('opened_at')
-            ->groupBy(DB::raw('strftime("%s", opened_at) / ' . $intervalInSeconds))
+            ->groupByRaw('strftime("%s", opened_at) / ' . $intervalInSeconds)
             ->orderBy('opened_at')
             ->get();
 

--- a/src/Repositories/Subscribers/SqliteSubscriberTenantRepository.php
+++ b/src/Repositories/Subscribers/SqliteSubscriberTenantRepository.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Sendportal\Base\Repositories\Subscribers;
+
+use Carbon\CarbonPeriod;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+
+class SqliteSubscriberTenantRepository extends BaseSubscriberTenantRepository
+{
+    /**
+     * @inheritDoc
+     */
+    public function getGrowthChartData(CarbonPeriod $period, int $workspaceId): array
+    {
+        $startingValue = DB::table('subscribers')
+            ->where('workspace_id', $workspaceId)
+            ->where(function (Builder $q) use ($period) {
+                $q->where('unsubscribed_at', '>=', $period->getStartDate())
+                    ->orWhereNull('unsubscribed_at');
+            })
+            ->where('created_at', '<', $period->getStartDate())
+            ->count();
+
+        $runningTotal = DB::table('subscribers')
+            ->selectRaw("strftime('%d-%m-%Y', created_at) AS date, count(*) as total")
+            ->where('workspace_id', $workspaceId)
+            ->where('created_at', '>=', $period->getStartDate())
+            ->where('created_at', '<=', $period->getEndDate())
+            ->groupBy('date')
+            ->get();
+
+        $unsubscribers = DB::table('subscribers')
+            ->selectRaw("strftime('%d-%m-%Y', unsubscribed_at) AS date, count(*) as total")
+            ->where('workspace_id', $workspaceId)
+            ->where('unsubscribed_at', '>=', $period->getStartDate())
+            ->where('unsubscribed_at', '<=', $period->getEndDate())
+            ->groupBy('date')
+            ->get();
+
+        return [
+            'startingValue' => $startingValue,
+            'runningTotal' => $runningTotal->flatten()->keyBy('date'),
+            'unsubscribers' => $unsubscribers->flatten()->keyBy('date'),
+        ];
+    }
+}

--- a/src/Traits/ResolvesDatabaseDriver.php
+++ b/src/Traits/ResolvesDatabaseDriver.php
@@ -4,6 +4,7 @@ namespace Sendportal\Base\Traits;
 
 use Illuminate\Database\MySqlConnection;
 use Illuminate\Database\PostgresConnection;
+use Illuminate\Database\SQLiteConnection;
 use Illuminate\Support\Facades\DB;
 
 trait ResolvesDatabaseDriver
@@ -26,5 +27,15 @@ trait ResolvesDatabaseDriver
     public function usingPostgres(): bool
     {
         return DB::connection() instanceof PostgresConnection;
+    }
+
+    /**
+     * Determine whether the application is using the Sqlite database driver.
+     *
+     * @return bool
+     */
+    public function usingSqlite(): bool
+    {
+        return DB::connection() instanceof SQLiteConnection;
     }
 }

--- a/tests/Unit/Repositories/SubscriberTenantRepositoryTest.php
+++ b/tests/Unit/Repositories/SubscriberTenantRepositoryTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Tests\Unit\Repositories;
+
+use Carbon\CarbonPeriod;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Sendportal\Base\Models\Subscriber;
+use Sendportal\Base\Repositories\Subscribers\SubscriberTenantRepositoryInterface;
+use Tests\SendportalTestSupportTrait;
+use Tests\TestCase;
+
+class SubscriberTenantRepositoryTest extends TestCase
+{
+    use RefreshDatabase;
+    use SendportalTestSupportTrait;
+
+    protected $repository;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repository = app()->make(SubscriberTenantRepositoryInterface::class);
+    }
+
+    /** @test */
+    function it_should_get_the_grow_chart_data()
+    {
+        $period = CarbonPeriod::create('2019-04-01', '2019-04-30');
+
+        [$workspace, $_] = $this->createUserAndWorkspace();
+
+        $data = $this->repository->getGrowthChartData($period, $workspace->id);
+
+        $this->assertArrayHasKey('startingValue', $data);
+        $this->assertArrayHasKey('runningTotal', $data);
+        $this->assertArrayHasKey('unsubscribers', $data);
+    }
+
+    /** @test */
+    function it_should_get_the_total_number_of_subscribers_created_before_the_reference_period()
+    {
+        $period = CarbonPeriod::create('2019-04-01', '2019-04-30');
+
+        [$workspace, $_] = $this->createUserAndWorkspace();
+
+        factory(Subscriber::class, 2)->create([
+            'workspace_id' => $workspace->id,
+            'created_at' => $period->getStartDate()->subDay()
+        ]);
+
+        $this->assertEquals(2, $this->repository->getGrowthChartData($period, $workspace->id)['startingValue']);
+    }
+
+    /** @test */
+    public function it_should_get_the_total_number_of_subscribers_in_the_reference_period_grouped_by_date()
+    {
+        $period = CarbonPeriod::create('2019-04-01', '2019-04-30');
+
+        [$workspace, $_] = $this->createUserAndWorkspace();
+
+        factory(Subscriber::class)->create([
+            'workspace_id' => $workspace->id,
+            'created_at' => $period->getStartDate()->addDay()
+        ]);
+        factory(Subscriber::class)->create([
+            'workspace_id' => $workspace->id,
+            'created_at' => $period->getEndDate()->subDay()
+        ]);
+
+        $ignored = factory(Subscriber::class)->create([
+            'workspace_id' => $workspace->id,
+            'created_at' => $period->getEndDate()->addDay()
+        ]);
+
+        $runningTotal = $this->repository->getGrowthChartData($period, $workspace->id)['runningTotal'];
+
+        $this->assertEquals(2, $runningTotal->count());
+    }
+
+    /** @test */
+    public function it_should_get_the_total_number_of_unsubscribers_in_the_reference_period_grouped_by_date()
+    {
+        $period = CarbonPeriod::create('2019-04-01', '2019-04-30');
+
+        [$workspace, $_] = $this->createUserAndWorkspace();
+
+        $unsubscribed_at = $period->getStartDate()->addWeek();
+
+        factory(Subscriber::class)->create([
+            'workspace_id' => $workspace->id,
+            'created_at' => $period->getStartDate()->addDay(),
+            'unsubscribed_at' => $unsubscribed_at
+        ]);
+        factory(Subscriber::class)->create([
+            'workspace_id' => $workspace->id,
+            'created_at' => $period->getEndDate()->subDay()
+        ]);
+
+        $unsubscribers = $this->repository->getGrowthChartData($period, $workspace->id)['unsubscribers'];
+
+        $this->assertEquals(1, $unsubscribers->count());
+        $this->assertTrue($unsubscribers->has($unsubscribed_at->format('d-m-Y')));
+        $this->assertEquals(1, $unsubscribers->get($unsubscribed_at->format('d-m-Y'))->total);
+    }
+}


### PR DESCRIPTION
This PR adds Sqlite support and defaults the testsuite to use a memory sqlite database.

Testing against MySQL or Postgres is as easy as typing `DB_CONNECTION=mysql` or `DB_CONNECTION=pgsql` before running `phpunit`