### PR TITLE
Bugfix - Segment Subscriber Sync on Update

### DIFF
--- a/src/Repositories/SegmentTenantRepository.php
+++ b/src/Repositories/SegmentTenantRepository.php
@@ -21,8 +21,6 @@ class SegmentTenantRepository extends BaseTenantRepository
 
         $this->executeSave($workspaceId, $instance, $data);
 
-        $this->syncSubscribers($instance, Arr::get($data, 'subscribers', []));
-
         return $instance;
     }
 

--- a/tests/Feature/Segments/SegmentsControllerTest.php
+++ b/tests/Feature/Segments/SegmentsControllerTest.php
@@ -103,7 +103,7 @@ class SegmentsControllerTest extends TestCase
     }
 
     /** @test */
-    function subscribers_are_not_synced_when_the_segment_is_updated()
+    public function subscribers_are_not_synced_when_the_segment_is_updated()
     {
         [$workspace, $user] = $this->createUserAndWorkspace();
         $subscribers = factory(Subscriber::class, 5)->create([


### PR DESCRIPTION
## Description
This PR resolves https://github.com/mettle/sendportal/issues/70 and corrects the behaviour of the segment repository's `update()` method. Previously, it would re-sync subscribers - expecting a `subscribers` key to be present in the request. This is probably reflective of old behaviour; we no longer allow subscribers to be updated in such a manner. 


