### PR TITLE
fix Amazon SES open and click notification

### DIFF
--- a/src/Http/Controllers/Api/Webhooks/SesWebhooksController.php
+++ b/src/Http/Controllers/Api/Webhooks/SesWebhooksController.php
@@ -21,11 +21,7 @@ class SesWebhooksController extends Controller
 
         Log::info('SES webhook received', ['payload' => $payload]);
 
-        $payloadType = $payload['Type'] ?? null;
-
-        if (!in_array($payloadType, ['SubscriptionConfirmation', 'Notification'], true)) {
-            return response('OK (not processed).');
-        }
+        $payloadType = $payload['eventType'] ?? null;
 
         event(new SesWebhookReceived($payload, $payloadType));
 

--- a/src/Listeners/Webhooks/HandleSesWebhook.php
+++ b/src/Listeners/Webhooks/HandleSesWebhook.php
@@ -38,7 +38,7 @@ class HandleSesWebhook implements ShouldQueue
             return;
         }
 
-        $event = json_decode(Arr::get($event->payload, 'Message'), true);
+        $event = $event->payload;
 
         if (!$event) {
             return;


### PR DESCRIPTION
Amazon SES changed the structure of the sent JSON.
Because of this, views and clicks in the database did not change.
Now everything works

https://docs.aws.amazon.com/ses/latest/DeveloperGuide/event-publishing-retrieving-sns-examples.html#event-publishing-retrieving-sns-click