### PR TITLE
[Feature] Add ability for Subscriber API store endpoint to also update

### DIFF
--- a/src/Http/Controllers/Api/SubscribersController.php
+++ b/src/Http/Controllers/Api/SubscribersController.php
@@ -45,7 +45,7 @@ class SubscribersController extends Controller
      */
     public function store(SubscriberStoreRequest $request, int $workspaceId): SubscriberResource
     {
-        $subscriber = $this->apiService->store($workspaceId, collect($request->validated()));
+        $subscriber = $this->apiService->storeOrUpdate($workspaceId, collect($request->validated()));
 
         $subscriber->load('segments');
 

--- a/src/Repositories/Subscribers/BaseSubscriberTenantRepository.php
+++ b/src/Repositories/Subscribers/BaseSubscriberTenantRepository.php
@@ -27,8 +27,8 @@ abstract class BaseSubscriberTenantRepository extends BaseTenantRepository imple
 
         $subscriber = $this->executeSave($workspaceId, $instance, Arr::except($data, ['segments']));
 
-        // only sync segments if its actually present. This means that users's must
-        // pass through an empty segments array if they want to delete all segments
+        // Only sync segments if its actually present. This means that users must
+        // pass through an empty segments array if they want to delete all segments.
         if (isset($data['segments'])) {
             $this->syncSegments($instance, Arr::get($data, 'segments', []));
         }
@@ -60,8 +60,8 @@ abstract class BaseSubscriberTenantRepository extends BaseTenantRepository imple
 
         $subscriber = $this->executeSave($workspaceId, $instance, Arr::except($data, ['segments', 'id']));
 
-        // only sync segments if its actually present. This means that users's must
-        // pass through an empty segments array if they want to delete all segments
+        // Only sync segments if its actually present. This means that users must
+        // pass through an empty segments array if they want to delete all segments.
         if (isset($data['segments'])) {
             $this->syncSegments($instance, Arr::get($data, 'segments', []));
         }

--- a/tests/Feature/API/SubscribersControllerTest.php
+++ b/tests/Feature/API/SubscribersControllerTest.php
@@ -146,7 +146,6 @@ class SubscribersControllerTest extends TestCase
         $subscriber->segments()->attach($segment->id);
 
         // when
-        $this->withoutExceptionHandling();
         $response = $this->delete(route('sendportal.api.subscribers.destroy', [
             'workspaceId' => $user->currentWorkspace()->id,
             'subscriber' => $subscriber->id,

--- a/tests/Feature/API/SubscribersControllerTest.php
+++ b/tests/Feature/API/SubscribersControllerTest.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Arr;
 use Sendportal\Base\Models\Segment;
+use Sendportal\Base\Models\Subscriber;
 use Tests\TestCase;
 
 class SubscribersControllerTest extends TestCase
@@ -18,57 +19,57 @@ class SubscribersControllerTest extends TestCase
     /** @test */
     public function the_subscribers_index_is_accessible_to_authorised_users()
     {
+        // given
         $user = $this->createUserWithWorkspace();
 
         $subscriber = $this->createSubscriber($user);
 
-        $route = route('sendportal.api.subscribers.index', [
+        // when
+        $response = $this->get(route('sendportal.api.subscribers.index', [
             'workspaceId' => $user->currentWorkspace()->id,
             'api_token' => $user->api_token,
-        ]);
+        ]));
 
-        $response = $this->get($route);
-
+        // then
         $response->assertStatus(200);
 
-        $expected = [
+        $response->assertJson([
             'data' => [
                 Arr::only($subscriber->toArray(), ['first_name', 'last_name', 'email'])
             ],
-        ];
-
-        $response->assertJson($expected);
+        ]);
     }
 
     /** @test */
     public function a_single_subscriber_is_accessible_to_authorised_users()
     {
+        // given
         $user = $this->createUserWithWorkspace();
 
         $subscriber = $this->createSubscriber($user);
 
-        $route = route('sendportal.api.subscribers.show', [
+        // when
+        $response = $this->get(route('sendportal.api.subscribers.show', [
             'workspaceId' => $user->currentWorkspace()->id,
             'subscriber' => $subscriber->id,
             'api_token' => $user->api_token,
-        ]);
+        ]));
 
-        $response = $this->get($route);
-
+        // then
         $response->assertStatus(200);
 
-        $expected = [
+        $response->assertJson([
             'data' => Arr::only($subscriber->toArray(), ['first_name', 'last_name', 'email']),
-        ];
-
-        $response->assertJson($expected);
+        ]);
     }
 
     /** @test */
     public function a_subscriber_can_be_created_by_authorised_users()
     {
+        // given
         $user = $this->createUserWithWorkspace();
 
+        // when
         $route = route('sendportal.api.subscribers.store', $user->currentWorkspace()->id);
 
         $request = [
@@ -79,6 +80,7 @@ class SubscribersControllerTest extends TestCase
 
         $response = $this->post($route, array_merge($request, ['api_token' => $user->api_token]));
 
+        // then
         $response->assertStatus(201);
         $this->assertDatabaseHas('subscribers', $request);
         $response->assertJson(['data' => $request]);
@@ -87,10 +89,12 @@ class SubscribersControllerTest extends TestCase
     /** @test */
     public function a_subscriber_can_be_updated_by_authorised_users()
     {
+        // given
         $user = $this->createUserWithWorkspace();
 
         $subscriber = $this->createSubscriber($user);
 
+        // when
         $route = route('sendportal.api.subscribers.update', [
             'workspaceId' => $user->currentWorkspace()->id,
             'subscriber' => $subscriber->id,
@@ -105,6 +109,7 @@ class SubscribersControllerTest extends TestCase
 
         $response = $this->put($route, $request);
 
+        // then
         $response->assertStatus(200);
         $this->assertDatabaseMissing('subscribers', $subscriber->toArray());
         $this->assertDatabaseHas('subscribers', $request);
@@ -114,18 +119,19 @@ class SubscribersControllerTest extends TestCase
     /** @test */
     public function a_subscriber_can_be_deleted_by_authorised_users()
     {
+        // given
         $user = $this->createUserWithWorkspace();
 
         $subscriber = $this->createSubscriber($user);
 
-        $route = route('sendportal.api.subscribers.destroy', [
+        // when
+        $response = $this->delete(route('sendportal.api.subscribers.destroy', [
             'workspaceId' => $user->currentWorkspace()->id,
             'subscriber' => $subscriber->id,
             'api_token' => $user->api_token,
-        ]);
+        ]));
 
-        $response = $this->delete($route);
-
+        // then
         $response->assertStatus(204);
     }
 
@@ -153,5 +159,97 @@ class SubscribersControllerTest extends TestCase
         $this->assertDatabaseMissing('segment_subscriber', [
             'subscriber_id' => $subscriber->id
         ]);
+    }
+
+    /** @test */
+    public function the_store_endpoint_can_update_subscriber_based_on_email_address()
+    {
+        // given
+        $user = $this->createUserWithWorkspace();
+
+        $subscriber = $this->createSubscriber($user);
+
+        // when
+        $route = route('sendportal.api.subscribers.store', $user->currentWorkspace()->id);
+
+        $updateData = [
+            'first_name' => $this->faker->firstName,
+            'last_name' => $this->faker->lastName,
+            'email' => $subscriber->email,
+        ];
+
+        $response = $this->post($route, array_merge($updateData, ['api_token' => $user->api_token]));
+
+        // then
+        $response->assertStatus(200);
+
+        $this->assertDatabaseHas('subscribers', array_merge($updateData, ['id' => $subscriber->id]));
+        $this->assertDatabaseCount('subscribers', 1);
+
+        $response->assertJson(['data' => $updateData]);
+    }
+
+    /** @test */
+    public function the_store_endpoint_allows_segments_to_be_added_with_the_subscriber()
+    {
+        // given
+        $user = $this->createUserWithWorkspace();
+
+        $segment = $this->createSegment($user);
+
+        // when
+        $route = route('sendportal.api.subscribers.store', $user->currentWorkspace()->id);
+
+        $request = [
+            'first_name' => $this->faker->firstName,
+            'last_name' => $this->faker->lastName,
+            'email' => $this->faker->email,
+            'segments' => [$segment->id]
+        ];
+
+        $response = $this->post($route, array_merge($request, ['api_token' => $user->api_token]));
+
+        // then
+        $response->assertStatus(201);
+
+        $this->assertDatabaseHas('subscribers', ['email' => $request['email']]);
+
+        $subscriber = Subscriber::with('segments')->where('email', $request['email'])->first();
+
+        self::assertContains($segment->id, $subscriber->segments->pluck('id'));
+    }
+
+    /** @test */
+    public function the_store_endpoint_allows_subscriber_segments_to_be_updated()
+    {
+        // given
+        $user = $this->createUserWithWorkspace();
+
+        $segment1 = $this->createSegment($user);
+        $segment2 = $this->createSegment($user);
+
+        $subscriber = $this->createSubscriber($user);
+        $subscriber->segments()->save($segment1);
+
+        // when
+        $route = route('sendportal.api.subscribers.store', $user->currentWorkspace()->id);
+
+        $request = [
+            'first_name' => $this->faker->firstName,
+            'last_name' => $this->faker->lastName,
+            'email' => $subscriber->email,
+            'segments' => [$segment2->id]
+        ];
+
+        $response = $this->post($route, array_merge($request, ['api_token' => $user->api_token]));
+
+        // then
+        $response->assertStatus(200);
+
+        $subscriber = $subscriber->fresh();
+        $subscriber->load('segments');
+
+        self::assertContains($segment2->id, $subscriber->segments->pluck('id'));
+        self::assertNotContains($segment1->id, $subscriber->segments->pluck('id'));
     }
 }


### PR DESCRIPTION
This adds (back?) the ability to update existing subscribers in a
workspace by POSTing to the store endpoint, where existing emails are
updated and new emails are stored as new subscribers.

This also applies to segments, so that existing subscribers can have
their segments updated using this method.