### PR TITLE
Spanish encoding field from_name

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -18,7 +18,6 @@
     <link href="{{ asset(mix('app.css', 'vendor/sendportal')) }}" rel="stylesheet">
 
     @stack('css')
-
 </head>
 <body>
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">


### PR DESCRIPTION
error for Spanish encoding in from_name field, causes emails sent to junk email example: Comit� JAS M�xico