### PR TITLE
Delete failed messages on subscriber deletion

### DIFF
--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -95,6 +95,10 @@ class Message extends BaseModel
         static::creating(function ($model) {
             $model->hash = $model->hash ?: Uuid::uuid4()->toString();
         });
+
+        static::deleting(function (self $message) {
+            $message->failures()->delete();
+        });
     }
 
     public function failures(): HasMany

--- a/src/Models/Subscriber.php
+++ b/src/Models/Subscriber.php
@@ -91,11 +91,6 @@ class Subscriber extends BaseModel
         static::deleting(
             function (self $subscriber) {
                 $subscriber->tags()->detach();
-
-                $subscriber->messages()->each(function (Message $message) {
-                    $message->failures()->delete();
-                });
-
                 $subscriber->messages()->delete();
             }
         );

--- a/src/Models/Subscriber.php
+++ b/src/Models/Subscriber.php
@@ -91,6 +91,11 @@ class Subscriber extends BaseModel
         static::deleting(
             function (self $subscriber) {
                 $subscriber->tags()->detach();
+
+                $subscriber->messages()->each(function (Message $message) {
+                    $message->failures()->delete();
+                });
+
                 $subscriber->messages()->delete();
             }
         );

--- a/src/Models/Subscriber.php
+++ b/src/Models/Subscriber.php
@@ -91,8 +91,9 @@ class Subscriber extends BaseModel
             function (self $subscriber) {
                 $subscriber->tags()->detach();
                 $subscriber->messages->each(static function (Message $message) {
-                    $message->delete();
+                    $message->failures()->delete();
                 });
+                $subscriber->messages()->delete();
             }
         );
     }

--- a/src/Models/Subscriber.php
+++ b/src/Models/Subscriber.php
@@ -90,7 +90,7 @@ class Subscriber extends BaseModel
         static::deleting(
             function (self $subscriber) {
                 $subscriber->tags()->detach();
-                $subscriber->messages->each(static function (Message $message) {
+                $subscriber->messages()->each(static function (Message $message) {
                     $message->failures()->delete();
                 });
                 $subscriber->messages()->delete();

--- a/src/Models/Subscriber.php
+++ b/src/Models/Subscriber.php
@@ -87,11 +87,12 @@ class Subscriber extends BaseModel
                 $model->hash = Uuid::uuid4()->toString();
             }
         );
-
         static::deleting(
             function (self $subscriber) {
                 $subscriber->tags()->detach();
-                $subscriber->messages()->delete();
+                $subscriber->messages->each(static function (Message $message) {
+                    $message->delete();
+                });
             }
         );
     }

--- a/tests/Unit/Models/MessageTest.php
+++ b/tests/Unit/Models/MessageTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Models;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Sendportal\Base\Models\Message;
+use Sendportal\Base\Models\MessageFailure;
+use Tests\TestCase;
+
+class MessageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function deleting_a_message_also_deletes_its_associated_failures()
+    {
+        // given
+        $message = Message::factory()->create();
+        $message->failures()->create();
+
+        // when
+        $message->delete();
+
+        // then
+        static::assertCount(0, Message::all());
+        static::assertCount(0, MessageFailure::all());
+    }
+}

--- a/tests/Unit/Models/SubscriberTest.php
+++ b/tests/Unit/Models/SubscriberTest.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Sendportal\Base\Models\Campaign;
 use Sendportal\Base\Models\Message;
+use Sendportal\Base\Models\MessageFailure;
 use Sendportal\Base\Models\Subscriber;
 use Tests\TestCase;
 
@@ -37,6 +38,25 @@ class SubscriberTest extends TestCase
         static::assertTrue($messages->contains($messageTwo));
         static::assertEquals(Campaign::class, $messageTwo->source_type);
         static::assertEquals($campaignTwo->id, $messageTwo->source_id);
+    }
+
+    /** @test */
+    public function deleting_a_subscriber_also_deletes_its_messages_and_any_failures_associated_to_them()
+    {
+        // given
+        $subscriber = Subscriber::factory()->create();
+        $message = Message::factory()->create([
+            'subscriber_id' => $subscriber->id,
+        ]);
+        $message->failures()->create();
+
+        // when
+        $subscriber->delete();
+
+        // then
+        static::assertCount(0, Subscriber::all());
+        static::assertCount(0, Message::all());
+        static::assertCount(0, MessageFailure::all());
     }
 
     /**


### PR DESCRIPTION
### Issue
https://github.com/mettle/sendportal/issues/116

### Description
Delete failed messages on subscriber deletion.