### PR TITLE
Support PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "authors": [],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3 || ^8.0",
         "ext-json": "*",
         "aws/aws-sdk-php-laravel": "^3.6",
         "doctrine/dbal": "^3.0",

--- a/src/Services/Content/MergeContentService.php
+++ b/src/Services/Content/MergeContentService.php
@@ -93,7 +93,7 @@ class MergeContentService
 
     protected function mergeContent(?string $customContent, string $templateContent): string
     {
-        return str_ireplace(['{{content}}', '{{ content }}'], $customContent, $templateContent);
+        return str_ireplace(['{{content}}', '{{ content }}'], $customContent ?: '', $templateContent);
     }
 
     protected function mergeTags(string $content, Message $message): string

--- a/tests/Feature/Content/MergeContentTest.php
+++ b/tests/Feature/Content/MergeContentTest.php
@@ -40,7 +40,7 @@ class MergeContentTest extends TestCase
     public function it_can_handle_a_null_value_for_campaign_content()
     {
         $content = null;
-        $message = $this->generateCampaignMessage(null, '<p>Hello this is some {{content}}</p>');
+        $message = $this->generateCampaignMessage($content, '<p>Hello this is some {{content}}</p>');
 
         $mergedContent = $this->mergeContent($message);
 


### PR DESCRIPTION
This PR introduces the support for PHP8.

All tests ran successfully, except the one updated in this PR: `str_ireplace()` is sensitive to the type of the `$replace` parameter in PHP 8, so only strings or array can be passed to the function.