### PR TITLE
PHP 8: Bug fix for str_ireplace - empty values

### DIFF
--- a/src/Services/Content/MergeContentService.php
+++ b/src/Services/Content/MergeContentService.php
@@ -133,7 +133,7 @@ class MergeContentService
         ];
 
         foreach ($tags as $key => $replace) {
-            $content = str_ireplace('{{' . $key . '}}', $replace, $content);
+            $content = str_ireplace('{{' . $key . '}}', $replace ?: '', $content);
         }
 
         return $content;

--- a/src/Services/Content/MergeSubjectService.php
+++ b/src/Services/Content/MergeSubjectService.php
@@ -44,7 +44,7 @@ class MergeSubjectService
         ];
 
         foreach ($tags as $key => $replace) {
-            $messageSubject = str_ireplace('{{' . $key . '}}', $replace, $messageSubject);
+            $messageSubject = str_ireplace('{{' . $key . '}}', $replace ?: '', $messageSubject);
         }
 
         return $messageSubject;


### PR DESCRIPTION
Hi,

Great work on the tool! I came across an issue when running it on PHP 8 with empty first name / last name values on Subscribers, I have included a fix here. Would love to see this merged on master as soon as possible :)

Thanks!