### PR TITLE
Ignore spaces when merging subscriber's tag to a message

### DIFF
--- a/src/Services/Content/MergeContentService.php
+++ b/src/Services/Content/MergeContentService.php
@@ -133,7 +133,7 @@ class MergeContentService
         ];
 
         foreach ($tags as $key => $replace) {
-            $content = str_ireplace('{{' . $key . '}}', $replace, $content);
+            $content = str_ireplace(["{{ $key }}", "{{$key}}"], $replace, $content);
         }
 
         return $content;


### PR DESCRIPTION
Make both {{email}} and {{ email }} work when merging
subscriber's tag to a message, in order to be consistent with other tags
(fe. {{ unsubscribe_url }}).