### PR TITLE
Fix mailgun webhook signing key

### DIFF
--- a/resources/views/email_services/options/mailgun.blade.php
+++ b/resources/views/email_services/options/mailgun.blade.php
@@ -1,3 +1,4 @@
 <x-sendportal.text-field name="settings[key]" :label="__('API Key')" :value="Arr::get($settings ?? [], 'key')" autocomplete="off" />
+<x-sendportal.text-field name="settings[webhook_key]" :label="__('Webhook Key')" :value="Arr::get($settings ?? [], 'webhook_key')" autocomplete="off" />
 <x-sendportal.text-field name="settings[domain]" :label="__('Domain')" :value="Arr::get($settings ?? [], 'domain')" />
 <x-sendportal.select-field name="settings[zone]" :label="__('Zone')" :options="['EU' => 'EU', 'US' => 'US']" :value="Arr::get($settings ?? [], 'zone')" />

--- a/src/Listeners/Webhooks/HandleMailgunWebhook.php
+++ b/src/Listeners/Webhooks/HandleMailgunWebhook.php
@@ -181,7 +181,7 @@ class HandleMailgunWebhook implements ShouldQueue
         }
 
         /** @var string|null $signingKey */
-        $signingKey = $emailservice->settings['key'] ?? null;
+        $signingKey = $emailservice->settings['webhook_key'] ?? null;
 
         if (!$signingKey) {
             return false;

--- a/src/Services/Webhooks/Mailgun/WebhookVerifier.php
+++ b/src/Services/Webhooks/Mailgun/WebhookVerifier.php
@@ -14,6 +14,6 @@ class WebhookVerifier
 //            return false;
 //        }
 
-        return hash_hmac('sha256', $timestamp . $token, $signingKey) === $signature;
+        return hash_equals(hash_hmac('sha256', $timestamp . $token, $signingKey), $signature);
     }
 }

--- a/tests/Feature/Webhooks/MailgunWebhooksTest.php
+++ b/tests/Feature/Webhooks/MailgunWebhooksTest.php
@@ -22,13 +22,13 @@ class MailgunWebhooksTest extends TestCase
     protected $route = 'sendportal.api.webhooks.mailgun';
 
     /** @var string */
-    protected $apiKey;
+    protected $webHookKey;
 
     public function setUp(): void
     {
         parent::setUp();
 
-        $this->apiKey = Str::random();
+        $this->webHookKey = Str::random();
     }
 
     /** @test */
@@ -172,7 +172,7 @@ class MailgunWebhooksTest extends TestCase
         $emailService = EmailService::factory()->create([
             'type_id' => EmailServiceType::MAILGUN,
             'settings' => [
-                'key' => $this->apiKey,
+                'webhook_key' => $this->webHookKey,
             ],
         ]);
 
@@ -192,7 +192,7 @@ class MailgunWebhooksTest extends TestCase
 
         $token = Str::random();
 
-        $signature = hash_hmac('sha256', $timestamp . $token, $this->apiKey);
+        $signature = hash_hmac('sha256', $timestamp . $token, $this->webHookKey);
 
         return [
             'event-data' => [


### PR DESCRIPTION
There is no setting field for mailgun webhook key. So this pull request fixed the mailgun webhook.