### PR TITLE
[API] keep tags attached to previous subscribers

### DIFF
--- a/src/Repositories/Subscribers/BaseSubscriberTenantRepository.php
+++ b/src/Repositories/Subscribers/BaseSubscriberTenantRepository.php
@@ -46,7 +46,7 @@ abstract class BaseSubscriberTenantRepository extends BaseTenantRepository imple
      */
     public function syncTags(Subscriber $subscriber, array $tags = [])
     {
-        return $subscriber->tags()->sync($tags);
+        return $subscriber->tags()->sync($tags, false);
     }
 
     /**


### PR DESCRIPTION
Sorry my english is not good!

I often have to work through the API and there are a few things that I feel need to be more suitable.
I don't see an api capable of **creating new subscribers in bulk** using the API (I'm ready to pr)
I proceed to create this API in the job queue, it's ok!
But job-queue can't return new subscriber list immediately so I can use API `POST /api/v1/tags/{tagId}/subscribers`

I proceed to add subscribers based on your api service but your tags sync default configuration will delete previously attached user tags, so I had to rewrite the service completely new just different configuration as below .

My PR is **default false** when sync tags but you can **enable the option with config**.