### PR TITLE
Fix null value of content for str_replace function

### DIFF
--- a/src/Models/Campaign.php
+++ b/src/Models/Campaign.php
@@ -258,7 +258,7 @@ class Campaign extends BaseModel
     public function getMergedContentAttribute(): ?string
     {
         if ($this->template_id) {
-            return str_replace(['{{content}}', '{{ content }}'], $this->content, $this->template->content);
+            return str_replace(['{{content}}', '{{ content }}'], $this->content ?? '', $this->template->content);
         }
 
         return $this->content;


### PR DESCRIPTION
str_replace only accepts 2nd parameter as a string or array.