### PR TITLE
Mutator set for is_open_tracking and is_click_tracking and Attribute Casting updated for all boolean values

### DIFF
--- a/src/Models/Campaign.php
+++ b/src/Models/Campaign.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 
 /**
  * @property int $id
@@ -387,5 +388,26 @@ class Campaign extends BaseModel
         }
 
         return $this->active_subscriber_count === $this->messages()->count();
+    }
+
+    /**
+     * Interact with `is_open_tracking` attribute.
+     */
+    protected function isOpenTracking(): Attribute
+    {
+        return Attribute::make(
+            get: fn(mixed $value) => (bool)$value,
+        );
+    }
+
+
+    /**
+     * Interact with `is_click_tracking` attribute.
+     */
+    protected function isClickTracking($value)
+    {
+        return Attribute::make(
+            get: fn(mixed $value) => (bool)$value,
+        );
     }
 }

--- a/src/Models/Campaign.php
+++ b/src/Models/Campaign.php
@@ -96,11 +96,11 @@ class Campaign extends BaseModel
             'workspace_id' => 'int',
             'template_id' => 'int',
             'email_service_id' => 'int',
-            'is_open_tracking' => 'bool',
-            'is_click_tracking' => 'bool',
+            'is_open_tracking' => 'boolean',
+            'is_click_tracking' => 'boolean',
             'scheduled_at' => 'datetime',
-            'save_as_draft' => 'bool',
-            'send_to_all' => 'bool',
+            'save_as_draft' => 'boolean',
+            'send_to_all' => 'boolean',
         ];
     }
 

--- a/src/Models/Campaign.php
+++ b/src/Models/Campaign.php
@@ -393,21 +393,17 @@ class Campaign extends BaseModel
     /**
      * Interact with `is_open_tracking` attribute.
      */
-    protected function isOpenTracking(): Attribute
+    protected function getIsOpenTrackingAttribute($value)
     {
-        return Attribute::make(
-            get: fn(mixed $value) => (bool)$value,
-        );
+        return (bool)$value;
     }
 
 
     /**
      * Interact with `is_click_tracking` attribute.
      */
-    protected function isClickTracking($value)
+    protected function getIsClickTrackingAttribute($value)
     {
-        return Attribute::make(
-            get: fn(mixed $value) => (bool)$value,
-        );
+        return (bool)$value;
     }
 }


### PR DESCRIPTION
- The issue is in sendportal_campaigns table we have 2 columns is_open_tracking and is_click_tracking , it have value stored as 0, 1 but the expected value by function is true/false
- as per laravel https://laravel.com/docs/10.x/eloquent-mutators#attribute-casting
- https://github.com/mettle/sendportal/issues/313