### PR TITLE
Fix: slow campaign query

### DIFF
--- a/src/Models/Campaign.php
+++ b/src/Models/Campaign.php
@@ -180,7 +180,7 @@ class Campaign extends BaseModel
 
     public function getSentCountAttribute(): int
     {
-        return $this->sent_messages->count();
+        return $this->sent_messages()->count();
     }
 
     public function getUnsentCountAttribute(): int
@@ -258,7 +258,7 @@ class Campaign extends BaseModel
     public function getMergedContentAttribute(): ?string
     {
         if ($this->template_id) {
-            return str_replace(['{{content}}', '{{ content }}'], $this->content, $this->template->content);
+            return str_replace(['{{content}}', '{{ content }}'], $this->content, $this->template()->value('content'));
         }
 
         return $this->content;


### PR DESCRIPTION
- To avoid automatically adding the sent_messages, template attribute to the model.
- To improve performance by not fetching the entire relationship data just to count the number of records.