### PR TITLE
Timezone for displayDate Helper defaults to config timezone

### DIFF
--- a/src/Services/Helper.php
+++ b/src/Services/Helper.php
@@ -19,6 +19,10 @@ class Helper
             return null;
         }
 
+        if (! $timezone) {
+            $timezone = config('app.timezone');
+        }
+        
         return Carbon::parse($date)->copy()->tz($timezone);
     }
 


### PR DESCRIPTION
If the user doesn't provide a timezone when calling displayDate Helper, the helper returns the name of the timezone and not the date (see Carbon::tz() usage).

<img width="558" alt="imagen" src="https://github.com/user-attachments/assets/d1c4459c-8440-4465-b981-b6442621539d" />


With this PR, the timezone defaults to the one configured on app.timezone.
