### PR TITLE
Remove 'id' from cancelled campaign status insert

### DIFF
--- a/database/migrations/2020_07_17_072137_add_cancelled_campaign_status.php
+++ b/database/migrations/2020_07_17_072137_add_cancelled_campaign_status.php
@@ -11,7 +11,6 @@ class AddCancelledCampaignStatus extends UpgradeMigration
 
         DB::table($campaign_statuses)
             ->insert([
-                'id' => 5,
                 'name' => 'Cancelled',
             ]);
     }


### PR DESCRIPTION
Fix #214