### PR TITLE
Add IDs to campaign statuses in migration

### DIFF
--- a/database/migrations/2017_04_28_223029_create_campaign_statuses_table.php
+++ b/database/migrations/2017_04_28_223029_create_campaign_statuses_table.php
@@ -20,10 +20,10 @@ class CreateCampaignStatusesTable extends UpgradeMigration
 
         DB::table('sendportal_campaign_statuses')
             ->insert([
-                ['name' => 'Draft'],
-                ['name' => 'Queued'],
-                ['name' => 'Sending'],
-                ['name' => 'Sent'],
+                ['id' => 1, 'name' => 'Draft'],
+                ['id' => 2, 'name' => 'Queued'],
+                ['id' => 3, 'name' => 'Sending'],
+                ['id' => 4, 'name' => 'Sent'],
             ]);
     }
 }


### PR DESCRIPTION
Some versions of MySQL/MariaDB do not increment by 1. Because the statuses are hardcoded, we need to guarantee the values are correct.