### PR TITLE
Improvement/remove unused query

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -1,5 +1,8 @@
 <?php
 
 return [
-    // ...
+    'list_unsubscribe' => [
+        'email' => null,
+        'url' => null,
+    ]
 ];

--- a/config/config.php
+++ b/config/config.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'command_output_path' => env('SENDPORTAL_COMMAND_OUTPUT_PATH'),
     'list_unsubscribe' => [
         'email' => null,
         'url' => null,

--- a/resources/views/campaigns/preview.blade.php
+++ b/resources/views/campaigns/preview.blade.php
@@ -98,7 +98,7 @@
                             <div class="checkbox">
                                 <label>
                                     <input name="tags[]" type="checkbox" value="{{ $tag->id }}">
-                                    {{ $tag->name }} ({{ $tag->activeSubscribers()->count() }} {{ __('subscribers') }})
+                                    {{ $tag->name }} ({{ $tag->subscribers_count }} {{ __('subscribers') }})
                                 </label>
                             </div>
                         @empty

--- a/resources/views/campaigns/preview.blade.php
+++ b/resources/views/campaigns/preview.blade.php
@@ -98,7 +98,7 @@
                             <div class="checkbox">
                                 <label>
                                     <input name="tags[]" type="checkbox" value="{{ $tag->id }}">
-                                    {{ $tag->name }} ({{ $tag->subscribers_count }} {{ __('subscribers') }})
+                                    {{ $tag->name }} <small class="badge badge-light">({{ number_format($tag->subscribers_count) }} {{ __('subscribers') }})</small>
                                 </label>
                             </div>
                         @empty

--- a/resources/views/campaigns/reports/bounces.blade.php
+++ b/resources/views/campaigns/reports/bounces.blade.php
@@ -31,7 +31,7 @@
                                     </div>
                                 @endforeach
                             </td>
-                            <td>{{ \Sendportal\Base\Facades\Helper::displayDate($message->bounced_at) }}</td>
+                            <td>{{ \Sendportal\Base\Facades\Helper::displayDate($message->bounced_at)?->format('Y-m-d H:i:s') }}</td>
                         </tr>
                     @empty
                         <tr>

--- a/resources/views/campaigns/reports/clicks.blade.php
+++ b/resources/views/campaigns/reports/clicks.blade.php
@@ -64,7 +64,7 @@
                             <a href="{{ route('sendportal.subscribers.show', $message->subscriber_id) }}">{{ $message->recipient_email }}</a>
                         </td>
                         <td>{{ $message->subject }}</td>
-                        <td>{{ \Sendportal\Base\Facades\Helper::displayDate($message->clicked_at) }}</td>
+                        <td>{{ \Sendportal\Base\Facades\Helper::displayDate($message->clicked_at)?->format('Y-m-d H:i:s') }}</td>
                         <td>{{ $message->click_count }}</td>
                     </tr>
                 @empty

--- a/resources/views/campaigns/reports/opens.blade.php
+++ b/resources/views/campaigns/reports/opens.blade.php
@@ -67,7 +67,7 @@
                                     <a href="{{ route('sendportal.subscribers.show', $message->subscriber_id) }}">{{ $message->recipient_email }}</a>
                                 </td>
                                 <td>{{ $message->subject }}</td>
-                                <td>{{ \Sendportal\Base\Facades\Helper::displayDate($message->opened_at) }}</td>
+                                <td>{{ \Sendportal\Base\Facades\Helper::displayDate($message->opened_at)?->format('Y-m-d H:i:s') }}</td>
                                 <td>{{ $message->open_count }}</td>
                             </tr>
                         @empty

--- a/resources/views/campaigns/reports/recipients.blade.php
+++ b/resources/views/campaigns/reports/recipients.blade.php
@@ -27,11 +27,11 @@
                         <tr>
                             <td><a href="{{ route('sendportal.subscribers.show', $message->subscriber_id) }}">{{ $message->recipient_email }}</a></td>
                             <td>{{ $message->subject }}</td>
-                            <td>{{ \Sendportal\Base\Facades\Helper::displayDate($message->delivered_at) }}</td>
-                            <td>{{ \Sendportal\Base\Facades\Helper::displayDate($message->opened_at) }}</td>
-                            <td>{{ \Sendportal\Base\Facades\Helper::displayDate($message->clicked_at) }}</td>
-                            <td>{{ \Sendportal\Base\Facades\Helper::displayDate($message->bounced_at) }}</td>
-                            <td>{{ \Sendportal\Base\Facades\Helper::displayDate($message->complained_at) }}</td>
+                            <td>{{ \Sendportal\Base\Facades\Helper::displayDate($message->delivered_at)?->format('Y-m-d H:i:s') }}</td>
+                            <td>{{ \Sendportal\Base\Facades\Helper::displayDate($message->opened_at)?->format('Y-m-d H:i:s') }}</td>
+                            <td>{{ \Sendportal\Base\Facades\Helper::displayDate($message->clicked_at)?->format('Y-m-d H:i:s') }}</td>
+                            <td>{{ \Sendportal\Base\Facades\Helper::displayDate($message->bounced_at)?->format('Y-m-d H:i:s') }}</td>
+                            <td>{{ \Sendportal\Base\Facades\Helper::displayDate($message->complained_at)?->format('Y-m-d H:i:s') }}</td>
                         </tr>
                     @empty
                         <tr>

--- a/resources/views/campaigns/reports/unsubscribes.blade.php
+++ b/resources/views/campaigns/reports/unsubscribes.blade.php
@@ -23,7 +23,7 @@
                         <tr>
                             <td><a href="{{ route('sendportal.subscribers.show', $message->subscriber_id) }}">{{ $message->recipient_email }}</a></td>
                             <td>{{ $message->subject }}</td>
-                            <td>{{ \Sendportal\Base\Facades\Helper::displayDate($message->unsubscribed_at) }}</td>
+                            <td>{{ \Sendportal\Base\Facades\Helper::displayDate($message->unsubscribed_at)?->format('Y-m-d H:i:s') }}</td>
                         </tr>
                     @empty
                         <tr>

--- a/resources/views/campaigns/show.blade.php
+++ b/resources/views/campaigns/show.blade.php
@@ -1,4 +1,4 @@
-@extends('common.template')
+@extends('sendportal::layouts.app')
 
 @section('heading')
     {{ __('Campaign') }}: {{ $campaign->name }}

--- a/resources/views/dashboard/index.blade.php
+++ b/resources/views/dashboard/index.blade.php
@@ -109,6 +109,13 @@
                             </tr>
                         @endforelse
                         </tbody>
+                        <tfoot>
+                            <tr>
+                                <th colspan="7">
+                                    <a href="{{ route('sendportal.campaigns.sent') }}">See all completed campaigns <i class="fa fa-arrow-right"></i></a>
+                                </th>
+                            </tr>
+                        </tfoot>
                     </table>
                 </div>
             </div>
@@ -162,6 +169,13 @@
                             </tr>
                         @endforelse
                         </tbody>
+                        <tfoot>
+                            <tr>
+                                <th colspan="5">
+                                    <a href="{{ route('sendportal.subscribers.index') }}">See all subscribers <i class="fa fa-arrow-right"></i></a>
+                                </th>
+                            </tr>
+                        </tfoot>
                     </table>
                 </div>
             </div>

--- a/resources/views/subscribers/index.blade.php
+++ b/resources/views/subscribers/index.blade.php
@@ -75,7 +75,6 @@
                 <tr>
                     <th>{{ __('Email') }}</th>
                     <th>{{ __('Name') }}</th>
-                    <th>{{ __('Tags') }}</th>
                     <th>{{ __('Created') }}</th>
                     <th>{{ __('Status') }}</th>
                     <th>{{ __('Actions') }}</th>
@@ -90,12 +89,6 @@
                             </a>
                         </td>
                         <td>{{ $subscriber->full_name }}</td>
-                        <td>
-                            @forelse($subscriber->tags as $tag)
-                                <span class="badge badge-light">{{ $tag->name }}</span>
-                            @empty
-                                -
-                            @endforelse
                         <td><span
                                 title="{{ $subscriber->created_at }}">{{ $subscriber->created_at->diffForHumans() }}</span>
                         </td>

--- a/src/Adapters/BaseMailAdapter.php
+++ b/src/Adapters/BaseMailAdapter.php
@@ -18,12 +18,4 @@ abstract class BaseMailAdapter implements MailAdapterInterface
     {
         $this->config = $config;
     }
-
-    protected function getListUnsubscribe(): string
-    {
-        return collect(config('sendportal.list_unsubscribe'))
-            ->filter()
-            ->map(fn($value, $key) => $key === 'email' ? "<mailto: $value>" : "<$value>")
-            ->implode(',');
-    }
 }

--- a/src/Adapters/BaseMailAdapter.php
+++ b/src/Adapters/BaseMailAdapter.php
@@ -18,4 +18,12 @@ abstract class BaseMailAdapter implements MailAdapterInterface
     {
         $this->config = $config;
     }
+
+    protected function getListUnsubscribe(): string
+    {
+        return collect(config('sendportal.list_unsubscribe'))
+            ->filter()
+            ->map(fn($value, $key) => $key === 'email' ? "<mailto: $value>" : "<$value>")
+            ->implode(',');
+    }
 }

--- a/src/Adapters/MailgunMailAdapter.php
+++ b/src/Adapters/MailgunMailAdapter.php
@@ -19,7 +19,7 @@ class MailgunMailAdapter extends BaseMailAdapter
         'EU' => 'https://api.eu.mailgun.net/v3'
     ];
 
-    public function send(string $fromEmail, string $fromName, string $toEmail, string $subject, MessageTrackingOptions $trackingOptions, string $content): string
+    public function send(string $fromEmail, string $fromName, string $toEmail, string $subject, MessageTrackingOptions $trackingOptions, string $content, array $headers): string
     {
         $parameters = [
             'from' => "{$fromName} <{$fromEmail}>",

--- a/src/Adapters/MailjetAdapter.php
+++ b/src/Adapters/MailjetAdapter.php
@@ -20,7 +20,7 @@ class MailjetAdapter extends BaseMailAdapter
         'US' => 'api.us.mailjet.com'
     ];
 
-    public function send(string $fromEmail, string $fromName, string $toEmail, string $subject, MessageTrackingOptions $trackingOptions, string $content): string
+    public function send(string $fromEmail, string $fromName, string $toEmail, string $subject, MessageTrackingOptions $trackingOptions, string $content, array $headers): string
     {
         $response = $this->resolveClient()->post(Resources::$Email, [
             'body' => [

--- a/src/Adapters/PostalAdapter.php
+++ b/src/Adapters/PostalAdapter.php
@@ -16,7 +16,7 @@ class PostalAdapter extends BaseMailAdapter
      * @throws TypeException
      * @throws \Throwable
      */
-    public function send(string $fromEmail, string $fromName, string $toEmail, string $subject, MessageTrackingOptions $trackingOptions, string $content): string
+    public function send(string $fromEmail, string $fromName, string $toEmail, string $subject, MessageTrackingOptions $trackingOptions, string $content, array $headers): string
     {
         $client = new Client('https://' . Arr::get($this->config, 'postal_host'), Arr::get($this->config, 'key'));
 

--- a/src/Adapters/PostmarkMailAdapter.php
+++ b/src/Adapters/PostmarkMailAdapter.php
@@ -14,7 +14,7 @@ class PostmarkMailAdapter extends BaseMailAdapter
     /** @var PostmarkClient */
     protected $client;
 
-    public function send(string $fromEmail, string $fromName, string $toEmail, string $subject, MessageTrackingOptions $trackingOptions, string $content): string
+    public function send(string $fromEmail, string $fromName, string $toEmail, string $subject, MessageTrackingOptions $trackingOptions, string $content, array $headers): string
     {
         $result = $this->resolveClient()->sendEmail(
             "{$fromName} <{$fromEmail}>",

--- a/src/Adapters/SendgridMailAdapter.php
+++ b/src/Adapters/SendgridMailAdapter.php
@@ -23,7 +23,7 @@ class SendgridMailAdapter extends BaseMailAdapter
      * @throws TypeException
      * @throws \Throwable
      */
-    public function send(string $fromEmail, string $fromName, string $toEmail, string $subject, MessageTrackingOptions $trackingOptions, string $content): string
+    public function send(string $fromEmail, string $fromName, string $toEmail, string $subject, MessageTrackingOptions $trackingOptions, string $content, array $headers): string
     {
         $email = new Mail();
         $email->setFrom($fromEmail, $fromName);

--- a/src/Adapters/SesMailAdapter.php
+++ b/src/Adapters/SesMailAdapter.php
@@ -25,31 +25,34 @@ class SesMailAdapter extends BaseMailAdapter
     {
         // TODO(david): It isn't clear whether it is possible to set per-message tracking for SES.
 
-        $result = $this->throttleSending(function () use ($fromEmail, $fromName, $toEmail, $subject, $trackingOptions, $content) {
-            return $this->resolveClient()->sendEmail([
-                'FromEmailAddress' => $fromName . ' <' . $fromEmail . '>',
+        $headers = array_map(fn ($key) => [
+            'Name' => $key,
+            'Value' => $headers[$key],
+        ], array_keys($headers));
 
-                'Destination' => [
-                    'ToAddresses' => [$toEmail],
-                ],
+        $result = $this->throttleSending(fn() => $this->resolveClient()->sendEmail([
+            'FromEmailAddress' => $fromName . ' <' . $fromEmail . '>',
 
-                'Content' => [
-                    'Simple' => [
-                        'Subject' => [
-                            'Data' => $subject,
-                        ],
-                        'Body' => [
-                            'Html' => [
-                                'Data' => $content,
-                            ],
-                        ],
-                        'Headers' => $headers,
+            'Destination' => [
+                'ToAddresses' => [$toEmail],
+            ],
+
+            'Content' => [
+                'Simple' => [
+                    'Subject' => [
+                        'Data' => $subject,
                     ],
+                    'Body' => [
+                        'Html' => [
+                            'Data' => $content,
+                        ],
+                    ],
+                    'Headers' => $headers,
                 ],
+            ],
 
-                'ConfigurationSetName' => Arr::get($this->config, 'configuration_set_name'),
-            ]);
-        });
+            'ConfigurationSetName' => Arr::get($this->config, 'configuration_set_name'),
+        ]));
 
         return $this->resolveMessageId($result);
     }

--- a/src/Adapters/SesMailAdapter.php
+++ b/src/Adapters/SesMailAdapter.php
@@ -27,11 +27,7 @@ class SesMailAdapter extends BaseMailAdapter
 
         $result = $this->throttleSending(function () use ($fromEmail, $fromName, $toEmail, $subject, $trackingOptions, $content) {
             $headers = [];
-
-            $listUnsubscribe = collect(config('sendportal.list_unsubscribe'))
-                ->filter()
-                ->map(fn($value, $key) => $key === 'email' ? "<mailto: $value>" : "<$value>")
-                ->implode(',');
+            $listUnsubscribe = $this->getListUnsubscribe();
 
             if ($listUnsubscribe) {
                 $headers[] = [

--- a/src/Adapters/SesMailAdapter.php
+++ b/src/Adapters/SesMailAdapter.php
@@ -26,6 +26,20 @@ class SesMailAdapter extends BaseMailAdapter
         // TODO(david): It isn't clear whether it is possible to set per-message tracking for SES.
 
         $result = $this->throttleSending(function () use ($fromEmail, $fromName, $toEmail, $subject, $trackingOptions, $content) {
+            $headers = [];
+
+            $listUnsubscribe = collect(config('sendportal.list_unsubscribe'))
+                ->filter()
+                ->map(fn($value, $key) => $key === 'email' ? "<mailto: $value>" : "<$value>")
+                ->implode(',');
+
+            if ($listUnsubscribe) {
+                $headers[] = [
+                    'Name' => 'List-Unsubscribe',
+                    'Value' => $listUnsubscribe,
+                ];
+            }
+
             return $this->resolveClient()->sendEmail([
                 'FromEmailAddress' => $fromName . ' <' . $fromEmail . '>',
 
@@ -43,6 +57,7 @@ class SesMailAdapter extends BaseMailAdapter
                                 'Data' => $content,
                             ],
                         ],
+                        'Headers' => $headers,
                     ],
                 ],
 

--- a/src/Adapters/SesMailAdapter.php
+++ b/src/Adapters/SesMailAdapter.php
@@ -86,6 +86,6 @@ class SesMailAdapter extends BaseMailAdapter
      */
     public function getSendQuota(): array
     {
-        return $this->resolveClient()->getAccount()->get('SendQuota')->toArray();
+        return $this->resolveClient()->getAccount()->get('SendQuota');
     }
 }

--- a/src/Adapters/SesMailAdapter.php
+++ b/src/Adapters/SesMailAdapter.php
@@ -21,21 +21,11 @@ class SesMailAdapter extends BaseMailAdapter
     /**
      * @throws BindingResolutionException
      */
-    public function send(string $fromEmail, string $fromName, string $toEmail, string $subject, MessageTrackingOptions $trackingOptions, string $content): string
+    public function send(string $fromEmail, string $fromName, string $toEmail, string $subject, MessageTrackingOptions $trackingOptions, string $content, array $headers): string
     {
         // TODO(david): It isn't clear whether it is possible to set per-message tracking for SES.
 
         $result = $this->throttleSending(function () use ($fromEmail, $fromName, $toEmail, $subject, $trackingOptions, $content) {
-            $headers = [];
-            $listUnsubscribe = $this->getListUnsubscribe();
-
-            if ($listUnsubscribe) {
-                $headers[] = [
-                    'Name' => 'List-Unsubscribe',
-                    'Value' => $listUnsubscribe,
-                ];
-            }
-
             return $this->resolveClient()->sendEmail([
                 'FromEmailAddress' => $fromName . ' <' . $fromEmail . '>',
 

--- a/src/Adapters/SmtpAdapter.php
+++ b/src/Adapters/SmtpAdapter.php
@@ -78,6 +78,11 @@ class SmtpAdapter extends BaseMailAdapter
             ->subject($subject)
             ->html($content);
 
+        $listUnsubscribe = $this->getListUnsubscribe();
+        if ($listUnsubscribe) {
+            $msg->getHeaders()->addHeader('List-Unsubscribe', $listUnsubscribe);
+        }
+
         return $msg;
     }
 

--- a/src/Adapters/SmtpAdapter.php
+++ b/src/Adapters/SmtpAdapter.php
@@ -21,10 +21,10 @@ class SmtpAdapter extends BaseMailAdapter
     /** @var EsmtpTransport */
     protected $transport;
 
-    public function send(string $fromEmail, string $fromName, string $toEmail, string $subject, MessageTrackingOptions $trackingOptions, string $content): string
+    public function send(string $fromEmail, string $fromName, string $toEmail, string $subject, MessageTrackingOptions $trackingOptions, string $content, array $headers): string
     {
         try {
-            $result = $this->resolveClient()->send($this->resolveMessage($subject, $content, $fromEmail, $fromName, $toEmail));
+            $result = $this->resolveClient()->send($this->resolveMessage($subject, $content, $fromEmail, $fromName, $toEmail, $headers));
         } catch (TransportException $e) {
             return $this->resolveMessageId(0);
         }
@@ -70,7 +70,7 @@ class SmtpAdapter extends BaseMailAdapter
         return $this->transport;
     }
 
-    protected function resolveMessage(string $subject, string $content, string $fromEmail, string $fromName, string $toEmail): Email
+    protected function resolveMessage(string $subject, string $content, string $fromEmail, string $fromName, string $toEmail, array $headers): Email
     {
         $msg = (new Email())
             ->from(new Address($fromEmail, $fromName))
@@ -78,9 +78,8 @@ class SmtpAdapter extends BaseMailAdapter
             ->subject($subject)
             ->html($content);
 
-        $listUnsubscribe = $this->getListUnsubscribe();
-        if ($listUnsubscribe) {
-            $msg->getHeaders()->addHeader('List-Unsubscribe', $listUnsubscribe);
+        foreach ($headers as $name => $value) {
+            $msg->getHeaders()->addHeader($name, $value);
         }
 
         return $msg;

--- a/src/Console/Commands/CampaignDispatchCommand.php
+++ b/src/Console/Commands/CampaignDispatchCommand.php
@@ -62,7 +62,7 @@ class CampaignDispatchCommand extends Command
      */
     protected function getQueuedCampaigns(): EloquentCollection
     {
-        return Campaign::where('status_id', CampaignStatus::STATUS_QUEUED)
+        return Campaign::whereIn('status_id', [CampaignStatus::STATUS_QUEUED, CampaignStatus::STATUS_SENDING])
             ->where('scheduled_at', '<=', now())
             ->get();
     }

--- a/src/Console/Kernel.php
+++ b/src/Console/Kernel.php
@@ -25,7 +25,11 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        $schedule->command(CampaignDispatchCommand::class)->everyMinute()->withoutOverlapping();
+        $schedule->command(CampaignDispatchCommand::class)
+            ->everyMinute()
+            ->withoutOverlapping()
+            ->appendOutputTo(config('sendportal.command_output_path', '/dev/null'));
+
         $schedule->command('horizon:snapshot')->everyFiveMinutes();
     }
 

--- a/src/Http/Controllers/Api/CampaignDispatchController.php
+++ b/src/Http/Controllers/Api/CampaignDispatchController.php
@@ -35,14 +35,14 @@ class CampaignDispatchController extends Controller
      */
     public function send(CampaignDispatchRequest $request, $campaignId)
     {
-        $campaign = $request->getCampaign(['email_service', 'messages']);
+//        $campaign = $request->getCampaign(['email_service', 'messages']);
         $workspaceId = Sendportal::currentWorkspaceId();
 
-        if ($this->quotaService->exceedsQuota($campaign->email_service, $campaign->unsent_count)) {
-            return response([
-                'message' => __('The number of subscribers for this campaign exceeds your SES quota')
-            ], 422);
-        }
+//        if ($this->quotaService->exceedsQuota($campaign->email_service, $campaign->unsent_count)) {
+//            return response([
+//                'message' => __('The number of subscribers for this campaign exceeds your SES quota')
+//            ], 422);
+//        }
 
         $campaign = $this->campaigns->update($workspaceId, $campaignId, [
             'status_id' => CampaignStatus::STATUS_QUEUED,

--- a/src/Http/Controllers/Api/CampaignTestController.php
+++ b/src/Http/Controllers/Api/CampaignTestController.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sendportal\Base\Http\Controllers\Api;
+
+use Exception;
+use Illuminate\Http\JsonResponse;
+use Sendportal\Base\Facades\Sendportal;
+use Sendportal\Base\Http\Controllers\Controller;
+use Sendportal\Base\Http\Requests\Api\CampaignTestRequest;
+use Sendportal\Base\Services\Messages\DispatchTestMessage;
+use Sendportal\Base\Services\Messages\MessageOptions;
+
+class CampaignTestController extends Controller
+{
+    /**
+     * @throws Exception
+     */
+    public function send(DispatchTestMessage $dispatchTestMessage, CampaignTestRequest $request): JsonResponse
+    {
+        $messageOptions = (new MessageOptions())
+            ->setTo($request->get('recipient_email'))
+            ->setFromEmail($request->get('from_email'))
+            ->setFromName($request->get('from_name'))
+            ->setSubject($request->get('subject'))
+            ->setBody($request->get('content'));
+
+        $messageId = $dispatchTestMessage->handleWithoutCampaign(
+            Sendportal::currentWorkspaceId(),
+            $request->get('email_service_id'),
+            $request->get('template_id'),
+            $messageOptions
+        );
+
+        if (! $messageId) {
+            return response()->json(['error', __('Failed to dispatch test email.')], 500);
+        }
+
+        return response()->json(['message' => __('The test email has been dispatched.')]);
+    }
+}

--- a/src/Http/Controllers/Api/CampaignsController.php
+++ b/src/Http/Controllers/Api/CampaignsController.php
@@ -118,10 +118,11 @@ class CampaignsController extends Controller
             Sendportal::currentWorkspaceId()
         );
 
-        $campaigns = $campaigns->map(function ($campaign) use ($campaignStats) {
+        $campaignsWithStats = $campaigns->map(function ($campaign) use ($campaignStats) {
             $campaign->stats = $campaignStats[$campaign->id];
             return $campaign;
         });
+        $campaigns->setCollection($campaignsWithStats);
 
         return CampaignStat::collection($campaigns);
     }

--- a/src/Http/Controllers/Api/CampaignsController.php
+++ b/src/Http/Controllers/Api/CampaignsController.php
@@ -99,7 +99,7 @@ class CampaignsController extends Controller
             $this->campaigns->paginate(
                 $workspaceId,
                 'idDesc',
-                ['status', 'opens', 'clicks'],
+                ['status'],
                 parameters: [
                     'name' => request('name'),
                 ]

--- a/src/Http/Controllers/Api/CampaignsController.php
+++ b/src/Http/Controllers/Api/CampaignsController.php
@@ -30,7 +30,16 @@ class CampaignsController extends Controller
     {
         $workspaceId = Sendportal::currentWorkspaceId();
 
-        return CampaignResource::collection($this->campaigns->paginate($workspaceId, 'id', ['tags']));
+        return CampaignResource::collection(
+            $this->campaigns->paginate(
+                $workspaceId,
+                'id',
+                ['tags'],
+                parameters: [
+                    'name' => request('name'),
+                ]
+            )
+        );
     }
 
     /**

--- a/src/Http/Controllers/Api/CampaignsController.php
+++ b/src/Http/Controllers/Api/CampaignsController.php
@@ -11,6 +11,7 @@ use Sendportal\Base\Facades\Sendportal;
 use Sendportal\Base\Http\Controllers\Controller;
 use Sendportal\Base\Http\Requests\Api\CampaignStoreRequest;
 use Sendportal\Base\Http\Resources\Campaign as CampaignResource;
+use Sendportal\Base\Http\Resources\CampaignStat;
 use Sendportal\Base\Repositories\Campaigns\CampaignTenantRepositoryInterface;
 
 class CampaignsController extends Controller
@@ -85,5 +86,24 @@ class CampaignsController extends Controller
         $campaign->tags()->sync($request->get('tags'));
 
         return new CampaignResource($campaign);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function stats(): AnonymousResourceCollection
+    {
+        $workspaceId = Sendportal::currentWorkspaceId();
+
+        return CampaignStat::collection(
+            $this->campaigns->paginate(
+                $workspaceId,
+                'idDesc',
+                ['status', 'opens', 'clicks'],
+                parameters: [
+                    'name' => request('name'),
+                ]
+            )
+        );
     }
 }

--- a/src/Http/Controllers/Api/SubscribersController.php
+++ b/src/Http/Controllers/Api/SubscribersController.php
@@ -136,6 +136,8 @@ class SubscribersController extends Controller
                         'last_name' => $subscriber['last_name'] ?? '',
                         'meta' => json_encode($subscriber['meta'] ?? ''),
                         'hash' => Uuid::uuid4()->toString(),
+                        'created_at' => now(),
+                        'updated_at' => now(),
                     ];
                 }
             }
@@ -211,6 +213,7 @@ class SubscribersController extends Controller
 
         $query = "UPDATE sendportal_subscribers SET ";
         $query .= "workspace_id = {$workspaceId}, ";
+        $query .= "updated_at = NOW(), ";
         $query .= "email = CASE id {$cases['email']} END, ";
         $query .= "first_name = CASE id {$cases['first_name']} END, ";
         $query .= "last_name = CASE id {$cases['last_name']} END, ";

--- a/src/Http/Controllers/Api/SubscribersController.php
+++ b/src/Http/Controllers/Api/SubscribersController.php
@@ -17,7 +17,6 @@ use Sendportal\Base\Http\Requests\Api\SubscribersSyncRequest;
 use Sendportal\Base\Http\Requests\Api\SubscriberStoreRequest;
 use Sendportal\Base\Http\Requests\Api\SubscriberUpdateRequest;
 use Sendportal\Base\Http\Resources\Subscriber as SubscriberResource;
-use Sendportal\Base\Models\Subscriber;
 use Sendportal\Base\Repositories\Subscribers\SubscriberTenantRepositoryInterface;
 use Sendportal\Base\Services\Subscribers\ApiSubscriberService;
 
@@ -113,7 +112,7 @@ class SubscribersController extends Controller
         $existingSubscribersIndex = $existingSubscribers->keyBy('email');
 
         // Process subscribers in chunks to reduce memory usage
-        $requestedSubscribers->chunk(100)->each(function ($chunk) use ($workspaceId, $existingSubscribersIndex) {
+        $requestedSubscribers->chunk(50)->each(function ($chunk) use ($workspaceId, $existingSubscribersIndex) {
             $toBeUpdated = [];
             $toBeInserted = [];
 

--- a/src/Http/Controllers/Api/SubscribersController.php
+++ b/src/Http/Controllers/Api/SubscribersController.php
@@ -161,7 +161,7 @@ class SubscribersController extends Controller
             ->where('workspace_id', $workspaceId)
             ->whereIn('email', $emails)
             ->orderBy('id')
-            ->get(['id', 'email', 'first_name', 'last_name']);
+            ->get(['id', 'email', 'first_name', 'last_name', 'unsubscribed_at', 'unsubscribe_event_id']);
 
         return SubscriberResource::collection($subscribers);
     }

--- a/src/Http/Controllers/Api/SubscribersController.php
+++ b/src/Http/Controllers/Api/SubscribersController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Response;
 use Sendportal\Base\Facades\Sendportal;
 use Sendportal\Base\Http\Controllers\Controller;
+use Sendportal\Base\Http\Requests\Api\SubscribersSyncRequest;
 use Sendportal\Base\Http\Requests\Api\SubscriberStoreRequest;
 use Sendportal\Base\Http\Requests\Api\SubscriberUpdateRequest;
 use Sendportal\Base\Http\Resources\Subscriber as SubscriberResource;
@@ -85,5 +86,17 @@ class SubscribersController extends Controller
         $this->apiService->delete($workspaceId, $this->subscribers->find($workspaceId, $id));
 
         return response(null, 204);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function sync(SubscribersSyncRequest $request): AnonymousResourceCollection
+    {
+        $workspaceId = Sendportal::currentWorkspaceId();
+        $subscribers = collect($request->validated('subscribers'))
+            ->map(fn($subscriber) => $this->apiService->storeOrUpdate($workspaceId, collect($subscriber)));
+
+        return SubscriberResource::collection($subscribers);
     }
 }

--- a/src/Http/Controllers/Api/SubscribersController.php
+++ b/src/Http/Controllers/Api/SubscribersController.php
@@ -149,6 +149,8 @@ class SubscribersController extends Controller
             $this->updateSubscribers(collect($toBeUpdated), $workspaceId);
         });
 
+        unset($requestedSubscribers, $existingSubscribers, $existingSubscribersIndex);
+
         // Fetch all subscribers that were just inserted or updated
         $subscribers = DB::table('sendportal_subscribers')
             ->whereIn('email', $emails)

--- a/src/Http/Controllers/Api/SubscribersController.php
+++ b/src/Http/Controllers/Api/SubscribersController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Response;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
+use Ramsey\Uuid\Uuid;
 use Sendportal\Base\Facades\Sendportal;
 use Sendportal\Base\Http\Controllers\Controller;
 use Sendportal\Base\Http\Requests\Api\SubscribersSyncRequest;
@@ -98,7 +99,7 @@ class SubscribersController extends Controller
     {
         $workspaceId = Sendportal::currentWorkspaceId();
         $requestedSubscribers = collect($request->validated('subscribers'));
-        $existingSubscribers = Subscriber::query()
+        $existingSubscribers = DB::table('sendportal_subscribers')
             ->whereIn('email', $requestedSubscribers->pluck('email'))
             ->get(['id', 'email']);
 
@@ -123,6 +124,7 @@ class SubscribersController extends Controller
                     'first_name' => $subscriber['first_name'] ?? '',
                     'last_name' => $subscriber['last_name'] ?? '',
                     'meta' => json_encode($subscriber['meta'] ?? ''),
+                    'hash' => Uuid::uuid4()->toString(),
                 ]);
             }
         }

--- a/src/Http/Controllers/Api/SubscribersController.php
+++ b/src/Http/Controllers/Api/SubscribersController.php
@@ -173,10 +173,12 @@ class SubscribersController extends Controller
             // Insert new subscribers
             if (!empty($toBeInserted)) {
                 DB::table('sendportal_subscribers')->insert($toBeInserted);
+                unset($toBeInserted);
             }
 
             // Update existing subscribers
             $this->updateSubscribers(collect($toBeUpdated), $workspaceId);
+            unset($toBeUpdated);
             $this->log('chunk_'.$key.'_finish');
         });
 

--- a/src/Http/Controllers/Api/SubscribersController.php
+++ b/src/Http/Controllers/Api/SubscribersController.php
@@ -158,6 +158,7 @@ class SubscribersController extends Controller
 
         // Fetch all subscribers that were just inserted or updated
         $subscribers = DB::table('sendportal_subscribers')
+            ->where('workspace_id', $workspaceId)
             ->whereIn('email', $emails)
             ->orderBy('id')
             ->get(['id', 'email', 'first_name', 'last_name']);

--- a/src/Http/Controllers/Api/SubscribersController.php
+++ b/src/Http/Controllers/Api/SubscribersController.php
@@ -7,12 +7,15 @@ namespace Sendportal\Base\Http\Controllers\Api;
 use Exception;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Response;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Sendportal\Base\Facades\Sendportal;
 use Sendportal\Base\Http\Controllers\Controller;
 use Sendportal\Base\Http\Requests\Api\SubscribersSyncRequest;
 use Sendportal\Base\Http\Requests\Api\SubscriberStoreRequest;
 use Sendportal\Base\Http\Requests\Api\SubscriberUpdateRequest;
 use Sendportal\Base\Http\Resources\Subscriber as SubscriberResource;
+use Sendportal\Base\Models\Subscriber;
 use Sendportal\Base\Repositories\Subscribers\SubscriberTenantRepositoryInterface;
 use Sendportal\Base\Services\Subscribers\ApiSubscriberService;
 
@@ -94,8 +97,99 @@ class SubscribersController extends Controller
     public function sync(SubscribersSyncRequest $request): AnonymousResourceCollection
     {
         $workspaceId = Sendportal::currentWorkspaceId();
-        $subscribers = collect($request->validated('subscribers'))
-            ->map(fn($subscriber) => $this->apiService->storeOrUpdate($workspaceId, collect($subscriber)));
+        $requestedSubscribers = collect($request->validated('subscribers'));
+        $existingSubscribers = Subscriber::query()
+            ->whereIn('email', $requestedSubscribers->pluck('email'))
+            ->get(['id', 'email']);
+
+        $toBeUpdatedSubscribers = collect([]);
+        $toBeInsertedSubscribers = collect([]);
+
+        foreach ($requestedSubscribers as $subscriber) {
+            $existingSubscriber = $existingSubscribers->firstWhere('email', $subscriber['email']);
+            if ($existingSubscriber && isset($existingSubscriber->id)) {
+                $toBeUpdatedSubscribers->push([
+                    'id' => $existingSubscriber->id,
+                    'workspace_id' => $workspaceId,
+                    'email' => $subscriber['email'],
+                    'first_name' => $subscriber['first_name'] ?? '',
+                    'last_name' => $subscriber['last_name'] ?? '',
+                    'meta' => json_encode($subscriber['meta'] ?? ''),
+                ]);
+            } else {
+                $toBeInsertedSubscribers->push([
+                    'workspace_id' => $workspaceId,
+                    'email' => $subscriber['email'],
+                    'first_name' => $subscriber['first_name'] ?? '',
+                    'last_name' => $subscriber['last_name'] ?? '',
+                    'meta' => json_encode($subscriber['meta'] ?? ''),
+                ]);
+            }
+        }
+
+        $toBeInsertedSubscribers->chunk(100)
+            ->each(function ($chunk) {
+                DB::table('sendportal_subscribers')->insert($chunk->toArray());
+            });
+
+        $toBeUpdatedSubscribers->chunk(100)
+            ->each(function (Collection $chunk) use ($workspaceId) {
+                if ($chunk->isEmpty()) {
+                    return;
+                }
+
+                $ids = $chunk->pluck('id')->toArray();
+                $connection = DB::connection();
+
+                $cases = [
+                    'email' => '',
+                    'first_name' => '',
+                    'last_name' => '',
+                    'meta' => '',
+                ];
+
+                foreach ($chunk as $item) {
+                    $id = $connection->escape($item['id']);
+                    $email = $connection->escape($item['email']);
+
+                    $cases['email'] .= "WHEN {$id} THEN {$email} ";
+
+                    if (empty($item['first_name'])) {
+                        $cases['first_name'] .= "WHEN {$id} THEN NULL ";
+                    } else {
+                        $firstName = $connection->escape($item['first_name']);
+                        $cases['first_name'] .= "WHEN {$id} THEN {$firstName} ";
+                    }
+
+                    if (empty($item['last_name'])) {
+                        $cases['last_name'] .= "WHEN {$id} THEN NULL ";
+                    } else {
+                        $lastName = $connection->escape($item['last_name']);
+                        $cases['last_name'] .= "WHEN {$id} THEN {$lastName} ";
+                    }
+
+                    $meta = $connection->escape($item['meta']);
+                    $cases['meta'] .= "WHEN {$id} THEN {$meta} ";
+                }
+
+                $idsList = implode(',', array_map(function($id) use ($connection) {
+                    return $connection->escape($id);
+                }, $ids));
+
+                $query = "UPDATE sendportal_subscribers SET ";
+                $query .= "workspace_id = {$workspaceId}, ";
+                $query .= "email = CASE id {$cases['email']} END, ";
+                $query .= "first_name = CASE id {$cases['first_name']} END, ";
+                $query .= "last_name = CASE id {$cases['last_name']} END, ";
+                $query .= "meta = CASE id {$cases['meta']} END ";
+                $query .= "WHERE id IN ({$idsList})";
+
+                DB::statement($query);
+            });
+
+        // Fetch all subscribers that were just inserted or updated
+        $emails = $requestedSubscribers->pluck('email')->toArray();
+        $subscribers = Subscriber::whereIn('email', $emails)->orderBy('id')->get();
 
         return SubscriberResource::collection($subscribers);
     }

--- a/src/Http/Controllers/Api/SubscribersController.php
+++ b/src/Http/Controllers/Api/SubscribersController.php
@@ -9,7 +9,6 @@ use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Response;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\LazyCollection;
 use Ramsey\Uuid\Uuid;
 use Sendportal\Base\Facades\Sendportal;
@@ -28,9 +27,6 @@ class SubscribersController extends Controller
 
     /** @var ApiSubscriberService */
     protected $apiService;
-    private string $uniqid;
-    private float $startTime;
-    private float $startMemory;
 
     public function __construct(
         SubscriberTenantRepositoryInterface $subscribers,
@@ -96,34 +92,15 @@ class SubscribersController extends Controller
         return response(null, 204);
     }
 
-    private function log(string $step): void
-    {
-        Log::debug('sync_subs', [
-            'id' => $this->uniqid,
-            'step' => $step,
-            'time' => round((hrtime(true) - $this->startTime) / 1e9, 2),
-            'memory' => round(memory_get_usage(true) / 1024 / 1024, 2),
-            'memory_diff' => round((memory_get_usage(true) - $this->startMemory) / 1024 / 1024, 2),
-            'peak' => round(memory_get_peak_usage(true) / 1024 / 1024, 2)
-        ]);
-    }
-
     /**
      * @throws Exception
      */
     public function sync(SubscribersSyncRequest $request): AnonymousResourceCollection
     {
-        $this->uniqid = Uuid::uuid4()->toString();
-        $this->startTime = hrtime(true);
-        $this->startMemory = memory_get_usage(true);
-
-        $this->log('start');
         $workspaceId = Sendportal::currentWorkspaceId();
 
         // Convert to LazyCollection to process items one at a time
         $requestedSubscribers = LazyCollection::make($request->validated('subscribers'));
-
-        $this->log('lazy_collection');
 
         // Get all emails first to fetch existing subscribers
         $emails = $requestedSubscribers->pluck('email')->all();
@@ -131,16 +108,11 @@ class SubscribersController extends Controller
             ->whereIn('email', $emails)
             ->get(['id', 'email']);
 
-        $this->log('query_existing');
-
         // Create index for faster lookups
         $existingSubscribersIndex = $existingSubscribers->keyBy('email');
 
-        $this->log('index_email');
-
         // Process subscribers in chunks to reduce memory usage
         $requestedSubscribers->chunk(50)->each(function ($chunk, $key) use ($workspaceId, $existingSubscribersIndex) {
-            $this->log('chunk_'.$key.'_start');
             $toBeUpdated = [];
             $toBeInserted = [];
 
@@ -168,7 +140,6 @@ class SubscribersController extends Controller
                 }
             }
 
-            $this->log('chunk_'.$key.'_filter');
 
             // Insert new subscribers
             if (!empty($toBeInserted)) {
@@ -179,20 +150,15 @@ class SubscribersController extends Controller
             // Update existing subscribers
             $this->updateSubscribers(collect($toBeUpdated), $workspaceId);
             unset($toBeUpdated);
-            $this->log('chunk_'.$key.'_finish');
         });
 
         unset($requestedSubscribers, $existingSubscribers, $existingSubscribersIndex);
-
-        $this->log('before_end');
 
         // Fetch all subscribers that were just inserted or updated
         $subscribers = DB::table('sendportal_subscribers')
             ->whereIn('email', $emails)
             ->orderBy('id')
             ->get(['id', 'email', 'first_name', 'last_name']);
-
-        $this->log('end');
 
         return SubscriberResource::collection($subscribers);
     }

--- a/src/Http/Controllers/Api/TagsController.php
+++ b/src/Http/Controllers/Api/TagsController.php
@@ -39,7 +39,9 @@ class TagsController extends Controller
         $workspaceId = Sendportal::currentWorkspaceId();
 
         return TagResource::collection(
-            $this->tags->paginate($workspaceId, 'name', [], request()->get('per_page', 25))
+            $this->tags->paginate($workspaceId, 'name', [], request()->get('per_page', 25), [
+                'name' => request()->get('name')
+            ])
         );
     }
 

--- a/src/Http/Controllers/Campaigns/CampaignDispatchController.php
+++ b/src/Http/Controllers/Campaigns/CampaignDispatchController.php
@@ -56,10 +56,10 @@ class CampaignDispatchController extends Controller
 
         $campaign->tags()->sync($request->get('tags'));
 
-        if ($this->quotaService->exceedsQuota($campaign->email_service, $campaign->unsent_count)) {
-            return redirect()->route('sendportal.campaigns.edit', $id)
-                ->withErrors(__('The number of subscribers for this campaign exceeds your SES quota'));
-        }
+//        if ($this->quotaService->exceedsQuota($campaign->email_service, $campaign->unsent_count)) {
+//            return redirect()->route('sendportal.campaigns.edit', $id)
+//                ->withErrors(__('The number of subscribers for this campaign exceeds your SES quota'));
+//        }
 
         $scheduledAt = $request->get('schedule') === 'scheduled' ? Carbon::parse($request->get('scheduled_at')) : now();
 

--- a/src/Http/Controllers/Campaigns/CampaignsController.php
+++ b/src/Http/Controllers/Campaigns/CampaignsController.php
@@ -151,7 +151,7 @@ class CampaignsController extends Controller
             $this->handleCheckboxes($request->validated())
         );
 
-        return redirect()->route('sendportal.campaigns.preview', $campaign->id);
+        return redirect()->route('sendportal.campaigns.preview', ['id' => $campaign->id, 'show_all_tags' => 0]);
     }
 
     /**
@@ -167,7 +167,10 @@ class CampaignsController extends Controller
             return redirect()->route('sendportal.campaigns.status', $id);
         }
 
-        $tags = $this->tags->all(Sendportal::currentWorkspaceId(), 'name');
+        $tags = $this->tags->all(Sendportal::currentWorkspaceId(), 'name', parameters: [
+            // This is a hack to only show tag specific to this campaign, but can be overridden by the query string.
+            'name' => request('show_all_tags') ? null : "Campaign: $campaign->name",
+        ]);
 
         return view('sendportal::campaigns.preview', compact('campaign', 'tags', 'subscriberCount'));
     }

--- a/src/Http/Controllers/Campaigns/CampaignsController.php
+++ b/src/Http/Controllers/Campaigns/CampaignsController.php
@@ -77,7 +77,7 @@ class CampaignsController extends Controller
     {
         $workspaceId = Sendportal::currentWorkspaceId();
         $params = ['sent' => true];
-        $campaigns = $this->campaigns->paginate($workspaceId, 'created_atDesc', ['status'], 25, $params);
+        $campaigns = $this->campaigns->paginate($workspaceId, 'created_atDesc', ['status'], 10, $params);
 
         return view('sendportal::campaigns.index', [
             'campaigns' => $campaigns,

--- a/src/Http/Controllers/Campaigns/CampaignsController.php
+++ b/src/Http/Controllers/Campaigns/CampaignsController.php
@@ -67,7 +67,6 @@ class CampaignsController extends Controller
 
         return view('sendportal::campaigns.index', [
             'campaigns' => $campaigns,
-            'campaignStats' => $this->campaignStatisticsService->getForPaginator($campaigns, $workspaceId),
         ]);
     }
 

--- a/src/Http/Controllers/DashboardController.php
+++ b/src/Http/Controllers/DashboardController.php
@@ -47,7 +47,7 @@ class DashboardController extends Controller
     public function index(): View
     {
         $workspaceId = Sendportal::currentWorkspaceId();
-        $completedCampaigns = $this->campaigns->completedCampaigns($workspaceId, ['status']);
+        $completedCampaigns = $this->campaigns->completedCampaigns($workspaceId, 10, ['status']);
         $subscriberGrowthChart = $this->getSubscriberGrowthChart($workspaceId);
 
         return view('sendportal::dashboard.index', [

--- a/src/Http/Controllers/DashboardController.php
+++ b/src/Http/Controllers/DashboardController.php
@@ -61,28 +61,34 @@ class DashboardController extends Controller
 
     protected function getSubscriberGrowthChart($workspaceId): array
     {
-        $period = CarbonPeriod::create(now()->subDays(30)->startOfDay(), now()->endOfDay());
+        return cache()->remember(
+            'sendportal_subscriber_growth_chart',
+            now()->addHour(),
+            function () use ($workspaceId) {
+                $period = CarbonPeriod::create(now()->subDays(30)->startOfDay(), now()->endOfDay());
 
-        $growthChartData = $this->subscribers->getGrowthChartData($period, $workspaceId);
+                $growthChartData = $this->subscribers->getGrowthChartData($period, $workspaceId);
 
-        $growthChart = [
-            'labels' => [],
-            'data' => [],
-        ];
+                $growthChart = [
+                    'labels' => [],
+                    'data' => [],
+                ];
 
-        $currentTotal = $growthChartData['startingValue'];
+                $currentTotal = $growthChartData['startingValue'];
 
-        foreach ($period as $date) {
-            $formattedDate = $date->format('d-m-Y');
+                foreach ($period as $date) {
+                    $formattedDate = $date->format('d-m-Y');
 
-            $periodValue = $growthChartData['runningTotal'][$formattedDate]->total ?? 0;
-            $periodUnsubscribe = $growthChartData['unsubscribers'][$formattedDate]->total ?? 0;
-            $currentTotal += $periodValue - $periodUnsubscribe;
+                    $periodValue = $growthChartData['runningTotal'][$formattedDate]->total ?? 0;
+                    $periodUnsubscribe = $growthChartData['unsubscribers'][$formattedDate]->total ?? 0;
+                    $currentTotal += $periodValue - $periodUnsubscribe;
 
-            $growthChart['labels'][] = $formattedDate;
-            $growthChart['data'][] = $currentTotal;
-        }
+                    $growthChart['labels'][] = $formattedDate;
+                    $growthChart['data'][] = $currentTotal;
+                }
 
-        return $growthChart;
+                return $growthChart;
+            }
+        );
     }
 }

--- a/src/Http/Controllers/Subscribers/SubscribersController.php
+++ b/src/Http/Controllers/Subscribers/SubscribersController.php
@@ -43,7 +43,7 @@ class SubscribersController extends Controller
         $subscribers = $this->subscriberRepo->paginate(
             Sendportal::currentWorkspaceId(),
             'email',
-            ['tags'],
+            [],
             50,
             request()->all()
         )->withQueryString();

--- a/src/Http/Requests/Api/CampaignTestRequest.php
+++ b/src/Http/Requests/Api/CampaignTestRequest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Sendportal\Base\Http\Requests\Api;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class CampaignTestRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'recipient_email' => [
+                'required',
+                'email',
+            ],
+            'name' => [
+                'required',
+                'max:255',
+            ],
+            'subject' => [
+                'required',
+                'max:255',
+            ],
+            'from_name' => [
+                'required',
+                'max:255',
+            ],
+            'from_email' => [
+                'required',
+                'max:255',
+                'email',
+            ],
+            'email_service_id' => [
+                'required',
+                'integer',
+                'exists:sendportal_email_services,id',
+            ],
+            'template_id' => [
+                'nullable',
+                'exists:sendportal_templates,id',
+            ],
+            'content' => [
+                Rule::requiredIf($this->template_id === null),
+            ],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'recipient_email.required' => __('A test email address is required.'),
+        ];
+    }
+}

--- a/src/Http/Requests/Api/SubscriberStoreRequest.php
+++ b/src/Http/Requests/Api/SubscriberStoreRequest.php
@@ -15,6 +15,7 @@ class SubscriberStoreRequest extends FormRequest
             'last_name' => ['nullable'],
             'email' => ['required', 'email'],
             'tags' => ['array', 'nullable'],
+            'meta' => ['array', 'nullable'],
             'unsubscribed_at' => ['nullable', 'date'],
         ];
     }

--- a/src/Http/Requests/Api/SubscribersSyncRequest.php
+++ b/src/Http/Requests/Api/SubscribersSyncRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sendportal\Base\Http\Requests\Api;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SubscribersSyncRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'subscribers' => ['required', 'array'],
+            'subscribers.*.first_name' => ['nullable'],
+            'subscribers.*.last_name' => ['nullable'],
+            'subscribers.*.email' => ['required', 'email'],
+            'subscribers.*.tags' => ['array', 'nullable'],
+            'subscribers.*.meta' => ['array', 'nullable'],
+            'subscribers.*.unsubscribed_at' => ['nullable', 'date'],
+        ];
+    }
+}

--- a/src/Http/Resources/CampaignStat.php
+++ b/src/Http/Resources/CampaignStat.php
@@ -18,16 +18,16 @@ class CampaignStat extends JsonResource
             'id' => $this->id,
             'name' => $this->name,
             'status_id' => $this->status_id,
-            'status_text' => $this->status->name,
+            'status_text' => $this->status_text,
             'from_name' => $this->from_name,
             'from_email' => $this->from_email,
             'sent_count' => $this->sent_count,
             'bounced_count' => $this->bounced_count,
-            'open_count' => $this->unique_open_count,
-            'click_count' => $this->unique_click_count,
-            'scheduled_at' => $this->scheduled_at ? $this->scheduled_at->toDateTimeString() : null,
-            'created_at' => $this->created_at->toDateTimeString(),
-            'updated_at' => $this->updated_at->toDateTimeString()
+            'open_count' => $this->open_count,
+            'click_count' => $this->click_count,
+            'scheduled_at' => $this->scheduled_at,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
         ];
     }
 }

--- a/src/Http/Resources/CampaignStat.php
+++ b/src/Http/Resources/CampaignStat.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Sendportal\Base\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class CampaignStat extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'status_id' => $this->status_id,
+            'status_text' => $this->status->name,
+            'from_name' => $this->from_name,
+            'from_email' => $this->from_email,
+            'sent_count' => $this->sent_count,
+            'bounced_count' => $this->bounced_count,
+            'open_count' => $this->unique_open_count,
+            'click_count' => $this->unique_click_count,
+            'scheduled_at' => $this->scheduled_at ? $this->scheduled_at->toDateTimeString() : null,
+            'created_at' => $this->created_at->toDateTimeString(),
+            'updated_at' => $this->updated_at->toDateTimeString()
+        ];
+    }
+}

--- a/src/Http/Resources/CampaignStat.php
+++ b/src/Http/Resources/CampaignStat.php
@@ -21,13 +21,10 @@ class CampaignStat extends JsonResource
             'status_text' => $this->status_text,
             'from_name' => $this->from_name,
             'from_email' => $this->from_email,
-            'sent_count' => $this->sent_count,
-            'bounced_count' => $this->bounced_count,
-            'open_count' => $this->open_count,
-            'click_count' => $this->click_count,
             'scheduled_at' => $this->scheduled_at,
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
+            'stats' => $this->stats,
         ];
     }
 }

--- a/src/Http/Resources/Subscriber.php
+++ b/src/Http/Resources/Subscriber.php
@@ -22,7 +22,8 @@ class Subscriber extends JsonResource
             'email' => $this->email,
 //            'tags' => TagResource::collection($this->whenLoaded('tags')),
 //            'meta' => $this->meta,
-//            'unsubscribed_at' => $this->unsubscribed_at ? $this->unsubscribed_at->toDateTimeString() : null,
+            'unsubscribed_at' => $this->unsubscribed_at ?? null,
+            'unsubscribe_event_id' => $this->unsubscribe_event_id ?? null,
 //            'created_at' => $this->created_at->toDateTimeString(),
 //            'updated_at' => $this->updated_at->toDateTimeString()
         ];

--- a/src/Http/Resources/Subscriber.php
+++ b/src/Http/Resources/Subscriber.php
@@ -21,6 +21,7 @@ class Subscriber extends JsonResource
             'last_name' => $this->last_name,
             'email' => $this->email,
             'tags' => TagResource::collection($this->whenLoaded('tags')),
+            'meta' => $this->meta,
             'unsubscribed_at' => $this->unsubscribed_at ? $this->unsubscribed_at->toDateTimeString() : null,
             'created_at' => $this->created_at->toDateTimeString(),
             'updated_at' => $this->updated_at->toDateTimeString()

--- a/src/Http/Resources/Subscriber.php
+++ b/src/Http/Resources/Subscriber.php
@@ -20,11 +20,11 @@ class Subscriber extends JsonResource
             'first_name' => $this->first_name,
             'last_name' => $this->last_name,
             'email' => $this->email,
-            'tags' => TagResource::collection($this->whenLoaded('tags')),
-            'meta' => $this->meta,
-            'unsubscribed_at' => $this->unsubscribed_at ? $this->unsubscribed_at->toDateTimeString() : null,
-            'created_at' => $this->created_at->toDateTimeString(),
-            'updated_at' => $this->updated_at->toDateTimeString()
+//            'tags' => TagResource::collection($this->whenLoaded('tags')),
+//            'meta' => $this->meta,
+//            'unsubscribed_at' => $this->unsubscribed_at ? $this->unsubscribed_at->toDateTimeString() : null,
+//            'created_at' => $this->created_at->toDateTimeString(),
+//            'updated_at' => $this->updated_at->toDateTimeString()
         ];
     }
 }

--- a/src/Http/Resources/Subscriber.php
+++ b/src/Http/Resources/Subscriber.php
@@ -3,7 +3,7 @@
 namespace Sendportal\Base\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
-use Sendportal\Base\Http\Resources\Tag as TagResource;
+//use Sendportal\Base\Http\Resources\Tag as TagResource;
 
 class Subscriber extends JsonResource
 {

--- a/src/Interfaces/MailAdapterInterface.php
+++ b/src/Interfaces/MailAdapterInterface.php
@@ -15,8 +15,9 @@ interface MailAdapterInterface
      * @param string $subject
      * @param MessageTrackingOptions $trackingOptions
      * @param string $content
+     * @param array $headers
      *
      * @return string
      */
-    public function send(string $fromEmail, string $fromName, string $toEmail, string $subject, MessageTrackingOptions $trackingOptions, string $content): string;
+    public function send(string $fromEmail, string $fromName, string $toEmail, string $subject, MessageTrackingOptions $trackingOptions, string $content, array $headers): string;
 }

--- a/src/Listeners/Webhooks/HandleSesWebhook.php
+++ b/src/Listeners/Webhooks/HandleSesWebhook.php
@@ -15,6 +15,9 @@ use Sendportal\Base\Services\Webhooks\EmailWebhookService;
 
 class HandleSesWebhook implements ShouldQueue
 {
+    /** @var string */
+    public $queue = 'sendportal-webhook-process';
+
     /** @var EmailWebhookService */
     private $emailWebhookService;
 

--- a/src/Listeners/Webhooks/HandleSesWebhook.php
+++ b/src/Listeners/Webhooks/HandleSesWebhook.php
@@ -163,6 +163,19 @@ class HandleSesWebhook implements ShouldQueue
         $bounceType = Arr::get($event, 'bounce.bounceType');
         $timestamp = Carbon::parse(Arr::get($event, 'bounce.timestamp'));
 
+        if (isset($event['bounce']['bouncedRecipients'][0]['action'])) {
+            $description = sprintf(
+                '%s - (%s) %s',
+                Arr::get($event, 'bounce.bounceSubType'),
+                Arr::get($event, 'bounce.bouncedRecipients.0.status'),
+                Arr::get($event, 'bounce.bouncedRecipients.0.diagnosticCode')
+            );
+        } else {
+            $description = Arr::get($event, 'bounce.bounceSubType');
+        }
+
+        $this->emailWebhookService->handleFailure($messageId, $bounceType, $description, $timestamp);
+
         // https://aws.amazon.com/blogs/messaging-and-targeting/handling-bounces-and-complaints/
         if (strtolower($bounceType) === 'permanent') {
             $this->emailWebhookService->handlePermanentBounce($messageId, $timestamp);

--- a/src/Models/Campaign.php
+++ b/src/Models/Campaign.php
@@ -219,7 +219,7 @@ class Campaign extends BaseModel
 
     public function getBouncedCountAttribute(): int
     {
-        return $this->bounced_messages->count();
+        return $this->bounced_messages()->count();
     }
 
     /**

--- a/src/Models/Campaign.php
+++ b/src/Models/Campaign.php
@@ -40,12 +40,14 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
  * @property EmailService|null $email_service
  * @property EloquentCollection $messages
  * @property EloquentCollection $sent_messages
+ * @property EloquentCollection $bounced_messages
  * @property EloquentCollection $opens
  * @property EloquentCollection $clicks
  *
  * @property-read int $active_subscriber_count_attribute
  * @property-read int $sent_count
  * @property-read int $unsent_count
+ * @property-read int $bounced_count
  * @property-read string $sent_count_formatted
  * @property-read float|int $open_ratio
  * @property-read float|int $click_ratio
@@ -151,6 +153,14 @@ class Campaign extends BaseModel
     }
 
     /**
+     * All of a campaign's bounced messages.
+     */
+    public function bounced_messages(): MorphMany
+    {
+        return $this->messages()->whereNotNull('bounced_at');
+    }
+
+    /**
      * All of a campaign's opened messages.
      */
     public function opens(): MorphMany
@@ -205,6 +215,11 @@ class Campaign extends BaseModel
         }
 
         return (string)$value;
+    }
+
+    public function getBouncedCountAttribute(): int
+    {
+        return $this->bounced_messages->count();
     }
 
     /**

--- a/src/Models/Campaign.php
+++ b/src/Models/Campaign.php
@@ -190,7 +190,7 @@ class Campaign extends BaseModel
 
     public function getSentCountAttribute(): int
     {
-        return $this->sent_messages->count();
+        return $this->sent_messages()->count();
     }
 
     public function getUnsentCountAttribute(): int

--- a/src/Models/Subscriber.php
+++ b/src/Models/Subscriber.php
@@ -62,6 +62,7 @@ class Subscriber extends BaseModel
     {
         return [
             'unsubscribed_at' => 'datetime',
+            'meta' => 'array',
         ];
     }
 

--- a/src/Repositories/Campaigns/BaseCampaignTenantRepository.php
+++ b/src/Repositories/Campaigns/BaseCampaignTenantRepository.php
@@ -25,11 +25,13 @@ abstract class BaseCampaignTenantRepository extends BaseTenantRepository impleme
     /**
      * {@inheritDoc}
      */
-    public function completedCampaigns(int $workspaceId, array $relations = []): EloquentCollection
+    public function completedCampaigns(int $workspaceId, int $limit = 10, array $relations = []): EloquentCollection
     {
         return $this->getQueryBuilder($workspaceId)
             ->where('status_id', CampaignStatus::STATUS_SENT)
             ->with($relations)
+            ->take($limit)
+            ->orderBy('id', 'desc')
             ->get();
     }
 

--- a/src/Repositories/Campaigns/BaseCampaignTenantRepository.php
+++ b/src/Repositories/Campaigns/BaseCampaignTenantRepository.php
@@ -131,12 +131,13 @@ abstract class BaseCampaignTenantRepository extends BaseTenantRepository impleme
         /** @var Tag $tag */
         $tag = $campaign->tags()->where('name', '=', 'Campaign: '.$campaign->name)->first();
 
-        /** Detach subscribers specific to this campaign */
+        /** Detach subscribers and delete tag specific to this campaign */
         if ($tag) {
             $tag->subscribers()->detach();
+            $tag->delete();
         }
 
-        /** Detach all tags from this campaign */
+        /** Detach all other tags used by this campaign */
         $campaign->tags()->detach();
 
         return parent::destroy($workspaceId, $id);

--- a/src/Repositories/Campaigns/BaseCampaignTenantRepository.php
+++ b/src/Repositories/Campaigns/BaseCampaignTenantRepository.php
@@ -40,25 +40,31 @@ abstract class BaseCampaignTenantRepository extends BaseTenantRepository impleme
      */
     public function getCounts(Collection $campaignIds, int $workspaceId): array
     {
-        $counts = DB::table('sendportal_campaigns')
-            ->leftJoin('sendportal_messages', function ($join) use ($campaignIds, $workspaceId) {
-                $join->on('sendportal_messages.source_id', '=', 'sendportal_campaigns.id')
-                    ->where('sendportal_messages.source_type', Campaign::class)
-                    ->whereIn('sendportal_messages.source_id', $campaignIds)
-                    ->where('sendportal_messages.workspace_id', $workspaceId);
-            })
-            ->select('sendportal_campaigns.id as campaign_id')
-            ->selectRaw(sprintf('count(%ssendportal_messages.id) as total', DB::getTablePrefix()))
-            ->selectRaw(sprintf('count(case when %ssendportal_messages.opened_at IS NOT NULL then 1 end) as opened', DB::getTablePrefix()))
-            ->selectRaw(sprintf('count(case when %ssendportal_messages.clicked_at IS NOT NULL then 1 end) as clicked', DB::getTablePrefix()))
-            ->selectRaw(sprintf('count(case when %ssendportal_messages.sent_at IS NOT NULL then 1 end) as sent', DB::getTablePrefix()))
-            ->selectRaw(sprintf('count(case when %ssendportal_messages.bounced_at IS NOT NULL then 1 end) as bounced', DB::getTablePrefix()))
-            ->selectRaw(sprintf('count(case when %ssendportal_messages.sent_at IS NULL then 1 end) as pending', DB::getTablePrefix()))
-            ->groupBy('sendportal_campaigns.id')
-            ->orderBy('sendportal_campaigns.id')
-            ->get();
+        return cache()->remember(
+            'sendportal_campaigns_counts:'.$campaignIds->implode(','),
+            60,
+            function () use ($campaignIds, $workspaceId) {
+                $counts = DB::table('sendportal_campaigns')
+                    ->leftJoin('sendportal_messages', function ($join) use ($campaignIds, $workspaceId) {
+                        $join->on('sendportal_messages.source_id', '=', 'sendportal_campaigns.id')
+                            ->where('sendportal_messages.source_type', Campaign::class)
+                            ->whereIn('sendportal_messages.source_id', $campaignIds)
+                            ->where('sendportal_messages.workspace_id', $workspaceId);
+                    })
+                    ->select('sendportal_campaigns.id as campaign_id')
+                    ->selectRaw(sprintf('count(%ssendportal_messages.id) as total', DB::getTablePrefix()))
+                    ->selectRaw(sprintf('count(case when %ssendportal_messages.opened_at IS NOT NULL then 1 end) as opened', DB::getTablePrefix()))
+                    ->selectRaw(sprintf('count(case when %ssendportal_messages.clicked_at IS NOT NULL then 1 end) as clicked', DB::getTablePrefix()))
+                    ->selectRaw(sprintf('count(case when %ssendportal_messages.sent_at IS NOT NULL then 1 end) as sent', DB::getTablePrefix()))
+                    ->selectRaw(sprintf('count(case when %ssendportal_messages.bounced_at IS NOT NULL then 1 end) as bounced', DB::getTablePrefix()))
+                    ->selectRaw(sprintf('count(case when %ssendportal_messages.sent_at IS NULL then 1 end) as pending', DB::getTablePrefix()))
+                    ->groupBy('sendportal_campaigns.id')
+                    ->orderBy('sendportal_campaigns.id')
+                    ->get();
 
-        return $counts->flatten()->keyBy('campaign_id')->toArray();
+                return $counts->flatten()->keyBy('campaign_id')->toArray();
+            }
+        );
     }
 
     /**

--- a/src/Repositories/Campaigns/BaseCampaignTenantRepository.php
+++ b/src/Repositories/Campaigns/BaseCampaignTenantRepository.php
@@ -85,6 +85,7 @@ abstract class BaseCampaignTenantRepository extends BaseTenantRepository impleme
     protected function applyFilters(Builder $instance, array $filters = []): void
     {
         $this->applySentFilter($instance, $filters);
+        $this->applyNameFilter($instance, $filters);
     }
 
     /**
@@ -107,6 +108,16 @@ abstract class BaseCampaignTenantRepository extends BaseTenantRepository impleme
             ];
 
             $instance->whereIn('status_id', $sentStatuses);
+        }
+    }
+
+    /**
+     * Filter by campaign name.
+     */
+    protected function applyNameFilter(Builder $instance, array $filters = []): void
+    {
+        if (Arr::get($filters, 'name')) {
+            $instance->where($instance->getModel()->getTable() . '.name', Arr::get($filters, 'name'));
         }
     }
 }

--- a/src/Repositories/Campaigns/CampaignTenantRepositoryInterface.php
+++ b/src/Repositories/Campaigns/CampaignTenantRepositoryInterface.php
@@ -24,7 +24,7 @@ interface CampaignTenantRepositoryInterface extends BaseTenantInterface
     /**
      * Campaigns that have been completed (have a SENT status).
      */
-    public function completedCampaigns(int $workspaceId, array $relations = []): EloquentCollection;
+    public function completedCampaigns(int $workspaceId, int $limit = 10, array $relations = []): EloquentCollection;
 
     /**
      * Get open counts and ratios for a campaign.

--- a/src/Repositories/TagTenantRepository.php
+++ b/src/Repositories/TagTenantRepository.php
@@ -2,6 +2,8 @@
 
 namespace Sendportal\Base\Repositories;
 
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Arr;
 use Sendportal\Base\Models\Tag;
 
 class TagTenantRepository extends BaseTenantRepository
@@ -46,5 +48,23 @@ class TagTenantRepository extends BaseTenantRepository
         $instance->campaigns()->detach();
 
         return $instance->delete();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function applyFilters(Builder $instance, array $filters = []): void
+    {
+        $this->applyNameFilter($instance, $filters);
+    }
+
+    /**
+     * Filter by name or email.
+     */
+    protected function applyNameFilter(Builder $instance, array $filters): void
+    {
+        if ($name = Arr::get($filters, 'name')) {
+            $instance->where($instance->getModel()->getTable() . '.name', $name);
+        }
     }
 }

--- a/src/Routes/ApiRoutes.php
+++ b/src/Routes/ApiRoutes.php
@@ -12,6 +12,7 @@ class ApiRoutes
     {
         return function () {
             $this->name('sendportal.api.')->prefix('v1')->namespace('\Sendportal\Base\Http\Controllers\Api')->group(static function (Router $apiRouter) {
+                $apiRouter->get('campaigns/stats', 'CampaignsController@stats')->name('campaigns.stats');
                 $apiRouter->apiResource('campaigns', 'CampaignsController');
                 $apiRouter->post('campaigns/{id}/send', 'CampaignDispatchController@send')->name('campaigns.send');
                 $apiRouter->apiResource('subscribers', 'SubscribersController');

--- a/src/Routes/ApiRoutes.php
+++ b/src/Routes/ApiRoutes.php
@@ -13,8 +13,10 @@ class ApiRoutes
         return function () {
             $this->name('sendportal.api.')->prefix('v1')->namespace('\Sendportal\Base\Http\Controllers\Api')->group(static function (Router $apiRouter) {
                 $apiRouter->get('campaigns/stats', 'CampaignsController@stats')->name('campaigns.stats');
+                $apiRouter->post('campaigns/send-test', 'CampaignTestController@send')->name('campaigns.send-test');
                 $apiRouter->apiResource('campaigns', 'CampaignsController');
                 $apiRouter->post('campaigns/{id}/send', 'CampaignDispatchController@send')->name('campaigns.send');
+
                 $apiRouter->apiResource('subscribers', 'SubscribersController');
                 $apiRouter->post('subscribers/sync', 'SubscribersController@sync')->name('subscribers.sync');
                 $apiRouter->apiResource('tags', 'TagsController');

--- a/src/Routes/ApiRoutes.php
+++ b/src/Routes/ApiRoutes.php
@@ -15,6 +15,7 @@ class ApiRoutes
                 $apiRouter->apiResource('campaigns', 'CampaignsController');
                 $apiRouter->post('campaigns/{id}/send', 'CampaignDispatchController@send')->name('campaigns.send');
                 $apiRouter->apiResource('subscribers', 'SubscribersController');
+                $apiRouter->post('subscribers/sync', 'SubscribersController@sync')->name('subscribers.sync');
                 $apiRouter->apiResource('tags', 'TagsController');
 
                 $apiRouter->apiResource('subscribers.tags', 'SubscriberTagsController')

--- a/src/Rules/CanAccessSubscriber.php
+++ b/src/Rules/CanAccessSubscriber.php
@@ -12,13 +12,16 @@ class CanAccessSubscriber implements Rule
 {
     public function passes($attribute, $value): bool
     {
-        $subscriber = Subscriber::find($value);
+        $workspaceId = Sendportal::currentWorkspaceId();
+        $subscriber = Subscriber::query()
+            ->where('workspace_id', $workspaceId)
+            ->find($value);
 
         if (! $subscriber) {
             return false;
         }
 
-        return $subscriber->workspace_id == Sendportal::currentWorkspaceId();
+        return $subscriber->workspace_id == $workspaceId;
     }
 
     /**

--- a/src/Services/Campaigns/CampaignDispatchService.php
+++ b/src/Services/Campaigns/CampaignDispatchService.php
@@ -23,8 +23,8 @@ class CampaignDispatchService
             return;
         }
 
-        if (! $campaign->queued) {
-            \Log::error('Campaign does not have a queued status campaign_id=' . $campaign->id . ' status_id=' . $campaign->status_id);
+        if (! $campaign->queued && ! $campaign->sending) {
+            \Log::error('Campaign does not have a queued or sending status campaign_id=' . $campaign->id . ' status_id=' . $campaign->status_id);
 
             return;
         }

--- a/src/Services/Campaigns/CampaignStatisticsService.php
+++ b/src/Services/Campaigns/CampaignStatisticsService.php
@@ -62,6 +62,7 @@ class CampaignStatisticsService
                     'bounce' => $countData[$campaign->id]->bounced,
                 ],
                 'ratios' => [
+                    'sent' => $campaign->getActionRatio($countData[$campaign->id]->sent, $countData[$campaign->id]->total),
                     'open' => $campaign->getActionRatio($countData[$campaign->id]->opened, $countData[$campaign->id]->sent),
                     'click' => $campaign->getActionRatio($countData[$campaign->id]->clicked, $countData[$campaign->id]->sent),
                     'bounce' => $campaign->getActionRatio($countData[$campaign->id]->bounced, $countData[$campaign->id]->sent),

--- a/src/Services/Campaigns/CampaignStatisticsService.php
+++ b/src/Services/Campaigns/CampaignStatisticsService.php
@@ -59,10 +59,12 @@ class CampaignStatisticsService
                     'open' => $countData[$campaign->id]->opened,
                     'click' => $countData[$campaign->id]->clicked,
                     'sent' => $countData[$campaign->id]->sent,
+                    'bounce' => $countData[$campaign->id]->bounced,
                 ],
                 'ratios' => [
                     'open' => $campaign->getActionRatio($countData[$campaign->id]->opened, $countData[$campaign->id]->sent),
                     'click' => $campaign->getActionRatio($countData[$campaign->id]->clicked, $countData[$campaign->id]->sent),
+                    'bounce' => $campaign->getActionRatio($countData[$campaign->id]->bounced, $countData[$campaign->id]->sent),
                 ],
             ];
         })->keyBy('campaign_id');

--- a/src/Services/Content/MergeContentService.php
+++ b/src/Services/Content/MergeContentService.php
@@ -39,6 +39,14 @@ class MergeContentService
         return $this->inlineStyles($this->resolveContent($message));
     }
 
+    public function handleTest(Message $message, string $template, $content): string
+    {
+        $content = $this->mergeContent($content, $template);
+        $content = $this->mergeTags($content, $message);
+
+        return $this->inlineStyles($content);
+    }
+
     /**
      * @throws Exception
      */

--- a/src/Services/Content/MergeContentService.php
+++ b/src/Services/Content/MergeContentService.php
@@ -131,7 +131,8 @@ class MergeContentService
         $tags = [
             'email' => $message->recipient_email,
             'first_name' => optional($message->subscriber)->first_name ?? '',
-            'last_name' => optional($message->subscriber)->last_name ?? ''
+            'last_name' => optional($message->subscriber)->last_name ?? '',
+            'name' => optional($message->subscriber)->first_name ?? '', // aliased to first name
         ];
 
         foreach ($tags as $key => $replace) {

--- a/src/Services/Content/MergeContentService.php
+++ b/src/Services/Content/MergeContentService.php
@@ -7,6 +7,7 @@ namespace Sendportal\Base\Services\Content;
 use Exception;
 use Sendportal\Base\Models\Campaign;
 use Sendportal\Base\Models\Message;
+use Sendportal\Base\Models\Subscriber;
 use Sendportal\Base\Repositories\Campaigns\CampaignTenantRepositoryInterface;
 use Sendportal\Base\Traits\NormalizeTags;
 use Sendportal\Pro\Repositories\AutomationScheduleRepository;
@@ -137,6 +138,10 @@ class MergeContentService
             $content = str_ireplace('{{' . $key . '}}', $replace, $content);
         }
 
+        if (optional($message->subscriber)->meta ?? false) {
+            $content = $this->resolveMergeSubscriberMetaService($message->subscriber)->handle($content);
+        }
+
         return $content;
     }
 
@@ -181,5 +186,10 @@ class MergeContentService
     protected function inlineStyles(string $content): string
     {
         return $this->cssProcessor->convert($content);
+    }
+
+    private function resolveMergeSubscriberMetaService(Subscriber $subscriber): MergeSubscriberMetaService
+    {
+        return new MergeSubscriberMetaService($subscriber);
     }
 }

--- a/src/Services/Content/MergeContentService.php
+++ b/src/Services/Content/MergeContentService.php
@@ -103,6 +103,7 @@ class MergeContentService
         $content = $this->mergeSubscriberTags($content, $message);
         $content = $this->mergeUnsubscribeLink($content, $message);
         $content = $this->mergeWebviewLink($content, $message);
+        $content = $this->mergeCustomTags($content, $message);
 
         return $content;
     }
@@ -161,6 +162,20 @@ class MergeContentService
     protected function generateWebviewLink(Message $message): string
     {
         return route('sendportal.webview.show', $message->hash);
+    }
+
+    protected function mergeCustomTags(string $content, Message $message): string
+    {
+        $tags = [
+            'current_year' => date('Y'),
+        ];
+
+        foreach ($tags as $key => $replace) {
+            $content = $this->normalizeTags($content, $key);
+            $content = str_ireplace('{{' . $key . '}}', $replace, $content);
+        }
+
+        return $content;
     }
 
     protected function inlineStyles(string $content): string

--- a/src/Services/Content/MergeSubscriberMetaService.php
+++ b/src/Services/Content/MergeSubscriberMetaService.php
@@ -32,7 +32,7 @@ class MergeSubscriberMetaService
 
     protected function compileTags(string $content): string
     {
-        foreach ($this->tags as $tag) {
+        foreach (array_keys($this->tags) as $tag) {
             $content = $this->normalizeTags($content, $tag);
         }
 
@@ -42,7 +42,7 @@ class MergeSubscriberMetaService
     protected function mergeMetaTagsValue(string $content): string
     {
         foreach ($this->tags as $tag => $value) {
-            $content = str_ireplace('{{' . $tag . '}}', $value, $content);
+            $content = str_ireplace('{{' . $tag . '}}', (string) $value, $content);
         }
 
         return $content;

--- a/src/Services/Content/MergeSubscriberMetaService.php
+++ b/src/Services/Content/MergeSubscriberMetaService.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sendportal\Base\Services\Content;
+
+use Sendportal\Base\Models\Subscriber;
+use Sendportal\Base\Traits\NormalizeTags;
+
+class MergeSubscriberMetaService
+{
+    use NormalizeTags;
+
+    private array $tags;
+
+    public function __construct(Subscriber $subscriber)
+    {
+        $this->tags = $subscriber->meta ?? [];
+    }
+
+    public function handle(string $content): string
+    {
+        return $this->mergeTags($content);
+    }
+
+    protected function mergeTags(string $content): string
+    {
+        return $this->mergeMetaTagsValue(
+            $this->compileTags($content)
+        );
+    }
+
+    protected function compileTags(string $content): string
+    {
+        foreach ($this->tags as $tag) {
+            $content = $this->normalizeTags($content, $tag);
+        }
+
+        return $content;
+    }
+
+    protected function mergeMetaTagsValue(string $content): string
+    {
+        foreach ($this->tags as $tag => $value) {
+            $content = str_ireplace('{{' . $tag . '}}', $value, $content);
+        }
+
+        return $content;
+    }
+}

--- a/src/Services/Helper.php
+++ b/src/Services/Helper.php
@@ -19,7 +19,7 @@ class Helper
             return null;
         }
 
-        return Carbon::parse($date)->copy()->tz($timezone);
+        return Carbon::parse($date)->copy()->tz($timezone ?? config('app.timezone'));
     }
 
     public function isPro(): bool

--- a/src/Services/Messages/DispatchMessage.php
+++ b/src/Services/Messages/DispatchMessage.php
@@ -104,7 +104,8 @@ class DispatchMessage
             ->setFromName($message->from_name)
             ->setSubject($message->subject)
             ->setTrackingOptions($trackingOptions)
-            ->addHeader('List-Unsubscribe', $this->getListUnsubscribe($message->subscriber));
+            ->addHeader('List-Unsubscribe', $this->getListUnsubscribe($message->subscriber))
+            ->addHeader('X-SendPortal-Campaign', $message->source->name);
 
         $messageId = $this->relayMessage->handle($mergedContent, $messageOptions, $emailService);
 

--- a/src/Services/Messages/DispatchMessage.php
+++ b/src/Services/Messages/DispatchMessage.php
@@ -101,7 +101,8 @@ class DispatchMessage
             ->setFromEmail($message->from_email)
             ->setFromName($message->from_name)
             ->setSubject($message->subject)
-            ->setTrackingOptions($trackingOptions);
+            ->setTrackingOptions($trackingOptions)
+            ->addHeader('List-Unsubscribe', $this->getListUnsubscribe());
 
         $messageId = $this->relayMessage->handle($mergedContent, $messageOptions, $emailService);
 
@@ -140,5 +141,13 @@ class DispatchMessage
         }
 
         return $campaign->status_id !== CampaignStatus::STATUS_CANCELLED;
+    }
+
+    protected function getListUnsubscribe(): string
+    {
+        return collect(config('sendportal.list_unsubscribe'))
+            ->filter()
+            ->map(fn($value, $key) => $key === 'email' ? "<mailto: $value>" : "<$value>")
+            ->implode(',');
     }
 }

--- a/src/Services/Messages/MessageOptions.php
+++ b/src/Services/Messages/MessageOptions.php
@@ -24,6 +24,9 @@ class MessageOptions
     /** @var MessageTrackingOptions */
     private $trackingOptions;
 
+    /** @var array<string, string> */
+    private $headers = [];
+
     /**
      * @return string
      */
@@ -101,6 +104,25 @@ class MessageOptions
     public function setTrackingOptions(MessageTrackingOptions $trackingOptions): self
     {
         $this->trackingOptions = $trackingOptions;
+
+        return $this;
+    }
+
+    public function getHeaders(): array
+    {
+        return $this->headers;
+    }
+
+    public function setHeaders(array $headers): self
+    {
+        $this->headers = $headers;
+
+        return $this;
+    }
+
+    public function addHeader(string $name, string $value): self
+    {
+        $this->headers[$name] = $value;
 
         return $this;
     }

--- a/src/Services/Messages/RelayMessage.php
+++ b/src/Services/Messages/RelayMessage.php
@@ -32,7 +32,8 @@ class RelayMessage
                 $messageOptions->getTo(),
                 $messageOptions->getSubject(),
                 $messageOptions->getTrackingOptions(),
-                $mergedContent
+                $mergedContent,
+                $messageOptions->getHeaders()
             );
     }
 }


### PR DESCRIPTION
### Verdicts

**`$withCount` adds overhead on `find()`**: The Tag model's `$withCount = ['subscribers']` appends a correlated count subquery even though `update()` never uses `subscribers_count`. The count is wasted here.

**`$withCount = ['subscribers']` on Tag model**: Every query on `Tag` (including the `find()` call here) carries a correlated subquery counting subscribers. This is unnecessary overhead inside `store()`.